### PR TITLE
fix(vectorstore): expose .stores shim + standalone Django bootstrap (#122)

### DIFF
--- a/ai-components/vector-store/README.md
+++ b/ai-components/vector-store/README.md
@@ -61,6 +61,39 @@ store.create_collection_from_nodes("my_collection", nodes)
 results, _ = store.search(collection_name="my_collection", query="AI programming", number=5)
 ```
 
+## PostgreSQL store (Django, FastAPI, or plain Python)
+
+The PostgreSQL store is exposed at a stable import path:
+
+```python
+from rakam_systems_vectorstore.stores import (
+    ConfigurablePgVectorStore,
+    VectorStoreConfig,
+)
+
+store = ConfigurablePgVectorStore(config=VectorStoreConfig())
+store.setup()  # creates the pgvector extension and tables if needed
+```
+
+The store connects through Django's ORM. **Inside a Django process** it uses your
+project's existing database configuration. **Outside Django** (FastAPI, workers,
+scripts) importing from `rakam_systems_vectorstore.stores` automatically
+configures Django from the `POSTGRES_*` environment variables — no
+`DJANGO_SETTINGS_MODULE` or `django.setup()` needed on your side. A host that has
+already configured Django is never overridden.
+
+To target a database other than the `POSTGRES_*` defaults, configure it
+explicitly before the first import from the store:
+
+```python
+from rakam_systems_vectorstore.config import DatabaseConfig
+from rakam_systems_vectorstore.stores import ensure_django_configured
+
+ensure_django_configured(DatabaseConfig(host="db.internal", database="tickets"))
+
+from rakam_systems_vectorstore.stores import ConfigurablePgVectorStore
+```
+
 ## Core Components
 
 - **ConfigurablePgVectorStore** — PostgreSQL with pgvector, hybrid search, keyword search

--- a/ai-components/vector-store/src/rakam_systems_vectorstore/__init__.py
+++ b/ai-components/vector-store/src/rakam_systems_vectorstore/__init__.py
@@ -35,11 +35,15 @@ from rakam_systems_vectorstore.config import (
 def __getattr__(name):
     """Lazy import Django-dependent components."""
     if name == "ConfigurablePgVectorStore":
+        from rakam_systems_vectorstore._django_setup import ensure_django_configured
+        ensure_django_configured()
         from rakam_systems_vectorstore.components.vectorstore.configurable_pg_vector_store import (
             ConfigurablePgVectorStore,
         )
         return ConfigurablePgVectorStore
     elif name == "PgVectorStore":
+        from rakam_systems_vectorstore._django_setup import ensure_django_configured
+        ensure_django_configured()
         from rakam_systems_vectorstore.components.vectorstore.pg_vector_store import PgVectorStore
         return PgVectorStore
     elif name == "AdaptiveLoader":

--- a/ai-components/vector-store/src/rakam_systems_vectorstore/_django_setup.py
+++ b/ai-components/vector-store/src/rakam_systems_vectorstore/_django_setup.py
@@ -1,0 +1,70 @@
+"""
+Lazy Django bootstrap for standalone (non-Django) consumers.
+
+The PostgreSQL vector store talks to Postgres through Django's ORM and
+``django.db.connection``. Inside a Django process this is already wired up, but
+when the package is used from a plain Python / FastAPI service there is no
+``DJANGO_SETTINGS_MODULE`` and importing the store raises
+``django.core.exceptions.ImproperlyConfigured``.
+
+``ensure_django_configured`` configures a minimal Django settings object from the
+package's :class:`~rakam_systems_vectorstore.config.DatabaseConfig` (i.e. the
+``POSTGRES_*`` environment variables) and runs ``django.setup()`` — but **only**
+when Django has not already been configured. A real Django host has
+``settings.configured`` set, so this is a no-op there and never overrides the
+host's configuration.
+
+The store always connects through Django's ``default`` database connection (it
+never reads ``vs_config.database`` for connecting), so bootstrapping from the
+same ``POSTGRES_*`` env vars is consistent with the in-Django behaviour.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from rakam_systems_vectorstore.config import DatabaseConfig
+
+# App that owns the Collection / NodeEntry models. Its AppConfig (apps.py)
+# registers under label "application", which the models declare explicitly.
+_VECTORSTORE_APP = "rakam_systems_vectorstore.components.vectorstore"
+
+
+def ensure_django_configured(db_config: "Optional[DatabaseConfig]" = None) -> None:
+    """Configure and set up Django for standalone use, if not already done.
+
+    Args:
+        db_config: Database connection settings. Defaults to ``DatabaseConfig()``,
+            which reads the ``POSTGRES_*`` environment variables.
+
+    This is idempotent and safe to call from any number of import sites: once
+    Django is configured (either by us or by a host Django project) it returns
+    immediately.
+    """
+    from django.conf import settings
+
+    if settings.configured:
+        return
+
+    import django
+    from rakam_systems_vectorstore.config import DatabaseConfig
+
+    db = db_config or DatabaseConfig()
+
+    settings.configure(
+        INSTALLED_APPS=[_VECTORSTORE_APP],
+        DATABASES={
+            "default": {
+                "ENGINE": "django.db.backends.postgresql",
+                "NAME": db.database,
+                "USER": db.user,
+                "PASSWORD": db.password,
+                "HOST": db.host,
+                "PORT": str(db.port),
+            }
+        },
+        DEFAULT_AUTO_FIELD="django.db.models.BigAutoField",
+        USE_TZ=True,
+    )
+    django.setup()

--- a/ai-components/vector-store/src/rakam_systems_vectorstore/stores.py
+++ b/ai-components/vector-store/src/rakam_systems_vectorstore/stores.py
@@ -1,0 +1,39 @@
+"""
+Stable import surface for the PostgreSQL vector store.
+
+This is the documented entry point for consumers (Django, FastAPI, or plain
+Python)::
+
+    from rakam_systems_vectorstore.stores import (
+        ConfigurablePgVectorStore,
+        VectorStoreConfig,
+    )
+
+Importing this module configures Django from the ``POSTGRES_*`` environment
+variables when running outside a Django process (see
+:mod:`rakam_systems_vectorstore._django_setup`). Inside a Django host it relies
+on the host's existing configuration and does nothing.
+
+To point the store at a database other than the ``POSTGRES_*`` defaults, call
+:func:`ensure_django_configured` with an explicit ``DatabaseConfig`` *before*
+importing from this module.
+"""
+
+from __future__ import annotations
+
+from rakam_systems_vectorstore._django_setup import ensure_django_configured
+
+# Bootstrap Django before importing the model-dependent store. Safe no-op when a
+# Django host has already configured settings.
+ensure_django_configured()
+
+from rakam_systems_vectorstore.components.vectorstore.configurable_pg_vector_store import (  # noqa: E402
+    ConfigurablePgVectorStore,
+)
+from rakam_systems_vectorstore.config import VectorStoreConfig  # noqa: E402
+
+__all__ = [
+    "ConfigurablePgVectorStore",
+    "VectorStoreConfig",
+    "ensure_django_configured",
+]

--- a/ai-components/vector-store/src/rakam_systems_vectorstore/tests/test_stores_shim.py
+++ b/ai-components/vector-store/src/rakam_systems_vectorstore/tests/test_stores_shim.py
@@ -1,0 +1,83 @@
+"""Regression tests for the public ``stores`` import surface and standalone
+Django bootstrap (issue #122).
+
+Django configuration is process-global, so each scenario runs in its own
+subprocess to keep them isolated from one another and from the rest of the
+suite. No live database is required: Django connects lazily, so importing the
+store and its models only needs settings to be configured.
+"""
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+django = pytest.importorskip("django")  # only meaningful with the [postgres] extra
+
+# Make the parent's import paths visible to the subprocesses.
+_ENV = {**os.environ, "PYTHONPATH": os.pathsep.join(sys.path)}
+_ENV.pop("DJANGO_SETTINGS_MODULE", None)
+
+
+def _run(snippet: str, extra_env: dict | None = None) -> str:
+    env = {**_ENV, **(extra_env or {})}
+    result = subprocess.run(
+        [sys.executable, "-c", snippet],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+def test_stores_import_resolves_documented_path():
+    """The exact import from the issue must resolve outside Django."""
+    out = _run(
+        "from rakam_systems_vectorstore.stores import "
+        "ConfigurablePgVectorStore, VectorStoreConfig;"
+        "print(ConfigurablePgVectorStore.__name__, VectorStoreConfig.__name__)"
+    )
+    assert out == "ConfigurablePgVectorStore VectorStoreConfig"
+
+
+def test_standalone_bootstrap_uses_postgres_env():
+    """Importing the shim configures Django from POSTGRES_* when unconfigured."""
+    out = _run(
+        "import rakam_systems_vectorstore.stores;"
+        "from django.conf import settings;"
+        "print(settings.DATABASES['default']['NAME'], settings.DATABASES['default']['HOST'])",
+        extra_env={"POSTGRES_DB": "tickets", "POSTGRES_HOST": "db.example.internal"},
+    )
+    assert out == "tickets db.example.internal"
+
+
+def test_django_dependent_models_import_standalone():
+    """pg_models (the original ImproperlyConfigured trigger) imports cleanly."""
+    out = _run(
+        "import rakam_systems_vectorstore.stores;"
+        "from rakam_systems_vectorstore.components.vectorstore.pg_models "
+        "import Collection, NodeEntry;"
+        "print(Collection.__name__, NodeEntry.__name__)"
+    )
+    assert out == "Collection NodeEntry"
+
+
+def test_existing_django_config_is_not_overridden():
+    """A host that already configured Django keeps its own DATABASES."""
+    out = _run(
+        "import django;"
+        "from django.conf import settings;"
+        "settings.configure("
+        "  INSTALLED_APPS=['rakam_systems_vectorstore.components.vectorstore'],"
+        "  DATABASES={'default': {'ENGINE': 'django.db.backends.postgresql',"
+        "    'NAME': 'HOST_OWNED_DB', 'USER': 'u', 'PASSWORD': 'p',"
+        "    'HOST': 'host.db', 'PORT': '5432'}},"
+        "  DEFAULT_AUTO_FIELD='django.db.models.BigAutoField', USE_TZ=True);"
+        "django.setup();"
+        "import rakam_systems_vectorstore.stores;"
+        "print(settings.DATABASES['default']['NAME'])",
+        extra_env={"POSTGRES_DB": "SHOULD_NOT_WIN"},
+    )
+    assert out == "HOST_OWNED_DB"


### PR DESCRIPTION
Fixes #122.

## Problem

`rakam-systems-vectorstore` was unusable from non-Django services (e.g. the `ots-ticket-service` / `ticket-rag` FastAPI worker):

1. **Missing `stores` module** — consumers import `from rakam_systems_vectorstore.stores import ConfigurablePgVectorStore, VectorStoreConfig`, but no such submodule existed.
2. **Hard Django bootstrap** — importing the store (or `pg_models`) raised `django.core.exceptions.ImproperlyConfigured`, because the package never configures Django and assumes a host Django process.

## Fix (issue option 1 + a lightweight slice of 2b)

- **`stores.py`** — new stable import surface that re-exports `ConfigurablePgVectorStore` and `VectorStoreConfig` at the documented path.
- **`_django_setup.ensure_django_configured()`** — configures Django from `DatabaseConfig` (the `POSTGRES_*` env vars) **only when settings are not already configured**. A Django host is never overridden (guarded by `settings.configured`).
- Top-level lazy imports (`from rakam_systems_vectorstore import ConfigurablePgVectorStore`) now self-bootstrap the same way.
- README documents the `.stores` path and the standalone behaviour.

Why this is safe and consistent: the store always connects through Django's `default` connection and never reads `vs_config.database` to connect, so bootstrapping from the same `POSTGRES_*` env vars matches the in-Django behaviour. `setup()` creates its tables via raw `CREATE TABLE IF NOT EXISTS` SQL, so **no `migrate` step is required**.

## Tests

`tests/test_stores_shim.py` (subprocess-isolated, since Django config is process-global):
- the exact import from the issue resolves outside Django
- standalone bootstrap reads `POSTGRES_*`
- `pg_models` (the original `ImproperlyConfigured` trigger) imports cleanly
- an existing Django host config is **not** overridden

Locally: 37 passed (shim + config). The 6 unrelated collection errors in the local env are missing `loaders` optional deps (`docling_core`).

## Notes
- **Version not bumped** — the Release workflow bumps + tags + publishes on dispatch. Enable `release_vectorstore` (patch) to ship 0.1.4.
- Follow-up (not in this PR): issue option 2a (full Django decoupling via psycopg/asyncpg) — recommend landing testcontainers-based regression tests for the Postgres path first, since it currently has none.