### PR TITLE
feat(vectorstore): ingestion capability primitives — pgvector loader, Neo4j stub, batched embedder (T1.3a/b, T1.4)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,6 +109,23 @@ jobs:
         strategy:
             matrix:
                 python-version: ["3.10", "3.11", "3.12"]
+        # pgvector-enabled Postgres so the ingestion loader's write path (COPY /
+        # executemany / jsonb / vector roundtrip) is actually exercised — those
+        # tests self-skip when PGVECTOR_TEST_DSN is unset.
+        services:
+            postgres:
+                image: pgvector/pgvector:pg16
+                env:
+                    POSTGRES_USER: postgres
+                    POSTGRES_PASSWORD: postgres
+                    POSTGRES_DB: test
+                ports:
+                    - 5432:5432
+                options: >-
+                    --health-cmd pg_isready
+                    --health-interval 10s
+                    --health-timeout 5s
+                    --health-retries 5
         steps:
             - uses: actions/checkout@v4
 
@@ -122,6 +139,8 @@ jobs:
 
             - name: Run VectorStore tests
               working-directory: ai-components/vector-store
+              env:
+                  PGVECTOR_TEST_DSN: postgresql://postgres:postgres@localhost:5432/test
               run: |
                   uv run pytest -v --cov --cov-report=term-missing || EXIT_CODE=$?
                   if [ "${EXIT_CODE:-0}" -eq 5 ]; then

--- a/ai-components/vector-store/pyproject.toml
+++ b/ai-components/vector-store/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rakam-systems-vectorstore"
-version = "0.2.0"
+version = "0.1.6"
 description = "Utility package for interacting with vectorstores"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/ai-components/vector-store/pyproject.toml
+++ b/ai-components/vector-store/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rakam-systems-vectorstore"
-version = "0.1.6"
+version = "0.2.0"
 description = "Utility package for interacting with vectorstores"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -39,6 +39,14 @@ postgres = [
     "psycopg2-binary>=2.9.9,<3.0.0",
     "pgvector>=0.3.0,<1.0.0",
     "django>=4.0.0,<6.0.0",
+]
+
+# Standalone (non-Django) loaders for the ephemeral ingestion job.
+# psycopg v3 is a distinct distribution from the Django stores' psycopg2-binary
+# (postgres extra), so the two coexist without a version clash; kept out of the
+# runtime import path by living behind this optional extra.
+ingestion = [
+    "psycopg[binary]>=3.1,<4.0",
 ]
 
 # FAISS backend for in-memory vector search

--- a/ai-components/vector-store/pyproject.toml
+++ b/ai-components/vector-store/pyproject.toml
@@ -77,7 +77,10 @@ loaders = [
     "beautifulsoup4>=4.12.0",
     "python-docx>=1.2.0",
     "pymupdf>=1.24.0",
-    "pymupdf4llm>=0.0.17",
+    # Cap <1.0: the 1.x line pulls `pymupdf-layout` -> `onnxruntime`, whose
+    # py<3.11 pin has no cp310 wheels (breaks the 3.10 leg) and drags a heavy ML
+    # tree. Unbounded, a fresh lock resolves to 1.x; this keeps the light 0.x.
+    "pymupdf4llm>=0.0.17,<1.0",
     "docling==2.62.0",
     "chonkie==1.4.2",
     "odfpy==1.4.1",

--- a/ai-components/vector-store/pyproject.toml
+++ b/ai-components/vector-store/pyproject.toml
@@ -47,6 +47,7 @@ postgres = [
 # runtime import path by living behind this optional extra.
 ingestion = [
     "psycopg[binary]>=3.1,<4.0",
+    "neo4j>=5.0,<6.0",
 ]
 
 # FAISS backend for in-memory vector search

--- a/ai-components/vector-store/src/rakam_systems_vectorstore/__init__.py
+++ b/ai-components/vector-store/src/rakam_systems_vectorstore/__init__.py
@@ -75,6 +75,15 @@ def __getattr__(name):
             GatewayEmbeddings,
         )
         return GatewayEmbeddings
+    elif name in ("PgVectorLoader", "PgVectorLoaderConfig"):
+        from rakam_systems_vectorstore.components.loader.pgvector_loader import (
+            PgVectorLoader,
+            PgVectorLoaderConfig,
+        )
+        return {
+            "PgVectorLoader": PgVectorLoader,
+            "PgVectorLoaderConfig": PgVectorLoaderConfig,
+        }[name]
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
@@ -104,6 +113,10 @@ __all__ = [
     # AI gateway embedder
     "build_embedder",
     "GatewayEmbeddings",
+
+    # Ingestion loaders (standalone, non-Django)
+    "PgVectorLoader",
+    "PgVectorLoaderConfig",
 
     # Original components (backward compatibility)
     "PgVectorStore",

--- a/ai-components/vector-store/src/rakam_systems_vectorstore/__init__.py
+++ b/ai-components/vector-store/src/rakam_systems_vectorstore/__init__.py
@@ -84,6 +84,15 @@ def __getattr__(name):
             "PgVectorLoader": PgVectorLoader,
             "PgVectorLoaderConfig": PgVectorLoaderConfig,
         }[name]
+    elif name in ("Neo4jLoader", "Neo4jLoaderConfig"):
+        from rakam_systems_vectorstore.components.loader.neo4j_loader import (
+            Neo4jLoader,
+            Neo4jLoaderConfig,
+        )
+        return {
+            "Neo4jLoader": Neo4jLoader,
+            "Neo4jLoaderConfig": Neo4jLoaderConfig,
+        }[name]
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
@@ -117,6 +126,8 @@ __all__ = [
     # Ingestion loaders (standalone, non-Django)
     "PgVectorLoader",
     "PgVectorLoaderConfig",
+    "Neo4jLoader",
+    "Neo4jLoaderConfig",
 
     # Original components (backward compatibility)
     "PgVectorStore",

--- a/ai-components/vector-store/src/rakam_systems_vectorstore/components/embedding_model/gateway_embeddings.py
+++ b/ai-components/vector-store/src/rakam_systems_vectorstore/components/embedding_model/gateway_embeddings.py
@@ -35,10 +35,22 @@ class GatewayEmbeddings(EmbeddingModel):
     stub with those is enough to unit-test the adapter.
     """
 
-    def __init__(self, embedder: Any, dim: int, name: str = "gateway_embeddings") -> None:
+    def __init__(
+        self,
+        embedder: Any,
+        dim: int,
+        name: str = "gateway_embeddings",
+        batch_size: int | None = None,
+    ) -> None:
         super().__init__(name=name)
         self._embedder = embedder
         self._dim = dim
+        # None -> hand all texts to the provider in one call (original behavior,
+        # what the 2 existing consumers get). A positive int chunks the corpus so
+        # the embed stage stays under provider per-request limits and O(batch)
+        # memory. Batches run in input order so vectors stay aligned with the
+        # caller's rows (the pgvector loader zips them positionally).
+        self._batch_size = batch_size
 
     def _to_vectors(self, result: Any) -> List[List[float]]:
         vectors = [list(v) for v in result.embeddings]
@@ -56,20 +68,43 @@ class GatewayEmbeddings(EmbeddingModel):
     def run(self, texts: List[str]) -> List[List[float]]:
         if not texts:
             return []
-        return self._to_vectors(self._embedder.embed_documents_sync(texts))
+        if not self._batch_size:
+            return self._to_vectors(self._embedder.embed_documents_sync(texts))
+        out: List[List[float]] = []
+        for i in range(0, len(texts), self._batch_size):
+            out.extend(
+                self._to_vectors(
+                    self._embedder.embed_documents_sync(texts[i : i + self._batch_size])
+                )
+            )
+        return out
 
     async def arun(self, texts: List[str]) -> List[List[float]]:
         if not texts:
             return []
-        return self._to_vectors(await self._embedder.embed_documents(texts))
+        if not self._batch_size:
+            return self._to_vectors(await self._embedder.embed_documents(texts))
+        out: List[List[float]] = []
+        for i in range(0, len(texts), self._batch_size):
+            out.extend(
+                self._to_vectors(
+                    await self._embedder.embed_documents(texts[i : i + self._batch_size])
+                )
+            )
+        return out
 
 
-def build_embedder(cfg: EmbeddingRef) -> EmbeddingModel:
+def build_embedder(cfg: EmbeddingRef, batch_size: int | None = None) -> EmbeddingModel:
     """Build an ``EmbeddingModel`` from a standardized :class:`EmbeddingRef`.
 
     Returns a live embedder ready for the vector stores' ``run(texts)`` call.
     pydantic-ai imports are lazy so importing this module never requires
     pydantic-ai unless the gateway path is actually used.
+
+    ``batch_size`` defaults to ``None`` — a single provider call, the behavior
+    the 2 existing product consumers rely on. The ingestion embed stage passes a
+    positive size to bound per-request payload/memory over a large corpus.
+    (``EmbeddingRef`` carries no batch field, so the param is the sole source.)
     """
     if cfg.provider in _LOCAL_PROVIDERS:
         from rakam_systems_vectorstore.components.embedding_model.configurable_embeddings import (
@@ -97,4 +132,4 @@ def build_embedder(cfg: EmbeddingRef) -> EmbeddingModel:
     # dimensions is applied to every request so the output width equals cfg.dim
     # (this is what produces the graph's 384-dim truncation of text-embedding-3-*).
     embedder = Embedder(model, settings=EmbeddingSettings(dimensions=cfg.dim))
-    return GatewayEmbeddings(embedder, dim=cfg.dim)
+    return GatewayEmbeddings(embedder, dim=cfg.dim, batch_size=batch_size)

--- a/ai-components/vector-store/src/rakam_systems_vectorstore/components/loader/__init__.py
+++ b/ai-components/vector-store/src/rakam_systems_vectorstore/components/loader/__init__.py
@@ -29,6 +29,8 @@ _DOCUMENT_LOADERS = {
 _INGESTION_LOADERS = {
     "PgVectorLoader": "pgvector_loader",
     "PgVectorLoaderConfig": "pgvector_loader",
+    "Neo4jLoader": "neo4j_loader",
+    "Neo4jLoaderConfig": "neo4j_loader",
 }
 
 

--- a/ai-components/vector-store/src/rakam_systems_vectorstore/components/loader/__init__.py
+++ b/ai-components/vector-store/src/rakam_systems_vectorstore/components/loader/__init__.py
@@ -1,31 +1,48 @@
-from .adaptive_loader import AdaptiveLoader, create_adaptive_loader
-from .code_loader import CodeLoader, create_code_loader
-from .doc_loader import DocLoader, create_doc_loader
-from .eml_loader import EmlLoader, create_eml_loader
-from .html_loader import HtmlLoader, create_html_loader
-from .md_loader import MdLoader, create_md_loader
-from .odt_loader import OdtLoader, create_odt_loader
-from .pdf_loader_light import PdfLoaderLight, create_pdf_loader_light
-from .tabular_loader import TabularLoader, create_tabular_loader
+# Lazy re-exports. The document loaders (adaptive/code/doc/eml/html/md/odt/pdf/
+# tabular) pull heavy optional deps (docling, pymupdf, ...) from the `loaders`
+# extra. Importing them eagerly here would force those deps onto anyone importing
+# a sibling module — notably the standalone pgvector/neo4j ingestion loaders,
+# which must import under only the light `ingestion` extra. So resolve each name
+# on access instead of at package import.
+
+_DOCUMENT_LOADERS = {
+    "AdaptiveLoader": "adaptive_loader",
+    "create_adaptive_loader": "adaptive_loader",
+    "CodeLoader": "code_loader",
+    "create_code_loader": "code_loader",
+    "DocLoader": "doc_loader",
+    "create_doc_loader": "doc_loader",
+    "EmlLoader": "eml_loader",
+    "create_eml_loader": "eml_loader",
+    "HtmlLoader": "html_loader",
+    "create_html_loader": "html_loader",
+    "MdLoader": "md_loader",
+    "create_md_loader": "md_loader",
+    "OdtLoader": "odt_loader",
+    "create_odt_loader": "odt_loader",
+    "PdfLoaderLight": "pdf_loader_light",
+    "create_pdf_loader_light": "pdf_loader_light",
+    "TabularLoader": "tabular_loader",
+    "create_tabular_loader": "tabular_loader",
+}
+
+_INGESTION_LOADERS = {
+    "PgVectorLoader": "pgvector_loader",
+    "PgVectorLoaderConfig": "pgvector_loader",
+}
+
+
+def __getattr__(name):
+    module = _DOCUMENT_LOADERS.get(name) or _INGESTION_LOADERS.get(name)
+    if module is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    import importlib
+
+    mod = importlib.import_module(f".{module}", __name__)
+    return getattr(mod, name)
+
 
 __all__ = [
-    "AdaptiveLoader",
-    "create_adaptive_loader",
-    "CodeLoader",
-    "create_code_loader",
-    "DocLoader",
-    "create_doc_loader",
-    "EmlLoader",
-    "create_eml_loader",
-    "HtmlLoader",
-    "create_html_loader",
-    "MdLoader",
-    "create_md_loader",
-    "OdtLoader",
-    "create_odt_loader",
-    "PdfLoaderLight",
-    "create_pdf_loader_light",
-    "TabularLoader",
-    "create_tabular_loader",
+    *_DOCUMENT_LOADERS,
+    *_INGESTION_LOADERS,
 ]
-

--- a/ai-components/vector-store/src/rakam_systems_vectorstore/components/loader/neo4j_loader.py
+++ b/ai-components/vector-store/src/rakam_systems_vectorstore/components/loader/neo4j_loader.py
@@ -1,0 +1,76 @@
+"""Generic Neo4j loader stub (D13).
+
+Deferred-use half of T1.3: we design the sink interface so a graph pipeline
+*could* run on it, but do NOT migrate ``ots-graph-generation-service`` now. So
+this is the minimal, contract-defining seam — a batched UNWIND writer over a
+caller-supplied Cypher statement — not a re-home of the graph service.
+
+Domain graph modelling (node labels, relationship types, MERGE keys) stays in
+the caller's Cypher + params; this only manages the driver/session and batches
+writes with bounded memory, mirroring PgVectorLoader's shape so the sink
+interface is symmetric.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Iterator
+
+
+def _batched(rows: Iterator[dict], size: int) -> Iterator[list[dict]]:
+    batch: list[dict] = []
+    for row in rows:
+        batch.append(row)
+        if len(batch) >= size:
+            yield batch
+            batch = []
+    if batch:
+        yield batch
+
+
+@dataclass
+class Neo4jLoaderConfig:
+    uri: str
+    user: str
+    password: str
+    database: str = "neo4j"
+    batch_size: int = 500
+
+
+class Neo4jLoader:
+    """Generic batched writer over a parametrized Cypher statement."""
+
+    def __init__(self, config: Neo4jLoaderConfig) -> None:
+        from neo4j import GraphDatabase
+
+        self.config = config
+        self._driver = GraphDatabase.driver(
+            config.uri, auth=(config.user, config.password)
+        )
+
+    def load(self, cypher: str, rows: Iterable[dict]) -> int:
+        """Run ``cypher`` once per batch with ``UNWIND $rows AS row ...``.
+
+        ``cypher`` MUST reference the ``$rows`` param — it is the batch payload.
+        Streams ``rows`` in ``batch_size`` groups; returns rows written.
+        """
+        if "$rows" not in cypher:
+            raise ValueError(
+                "cypher must reference the $rows parameter "
+                "(e.g. 'UNWIND $rows AS row ...') — it is the batch payload"
+            )
+
+        total = 0
+        with self._driver.session(database=self.config.database) as session:
+            for batch in _batched(iter(rows), self.config.batch_size):
+                session.execute_write(
+                    lambda tx, b=batch: tx.run(cypher, rows=b).consume()
+                )
+                total += len(batch)
+        return total
+
+    def verify_connectivity(self) -> None:
+        """``driver.verify_connectivity()`` passthrough — the connectivity proof."""
+        self._driver.verify_connectivity()
+
+    def close(self) -> None:
+        self._driver.close()

--- a/ai-components/vector-store/src/rakam_systems_vectorstore/components/loader/pgvector_loader.py
+++ b/ai-components/vector-store/src/rakam_systems_vectorstore/components/loader/pgvector_loader.py
@@ -1,0 +1,116 @@
+"""Standalone, Django-free pgvector loader for the ingestion job.
+
+The library's ``ConfigurablePgVectorStore`` / ``PgVectorStore`` are bound to the
+Django ORM (``django.db.connection``, ``NodeEntry.objects.bulk_create``) and need
+a configured Django app to run. The ephemeral ingestion job (one-shot container /
+CI ``workflow_dispatch``) has no Django project and must not acquire one, so this
+reuses the *SQL insert shape* proven in ``ConfigurablePgVectorStore.add`` — the
+``content, embedding, ...custom_metadata::jsonb`` columns and the ``[..]`` vector
+literal — but issues it over plain ``psycopg`` (v3) so it runs anywhere.
+
+Domain-agnostic on purpose (D5): the seed stage owns the ticket-rag column
+mapping and hands this loader ``columns`` + per-row dicts. This module knows only
+universal nouns — table, columns, rows, vectors.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, Iterator
+
+
+def _vector_literal(vector: list[float]) -> str:
+    """Render a pgvector text literal: ``[0.1,0.2]`` for ``[0.1, 0.2]``.
+
+    pgvector accepts the same bracketed form on both the COPY text stream and a
+    ``%s::vector`` insert param, so one formatter serves both paths.
+    """
+    return "[" + ",".join(map(str, vector)) + "]"
+
+
+def _batched(pairs: Iterator[tuple[dict, list[float]]], size: int) -> Iterator[list[tuple[dict, list[float]]]]:
+    batch: list[tuple[dict, list[float]]] = []
+    for pair in pairs:
+        batch.append(pair)
+        if len(batch) >= size:
+            yield batch
+            batch = []
+    if batch:
+        yield batch
+
+
+@dataclass
+class PgVectorLoaderConfig:
+    dsn: str
+    table: str
+    columns: list[str] = field(default_factory=list)
+    vector_column: str = "embedding"
+    batch_size: int = 500
+    use_copy: bool = True
+
+
+class PgVectorLoader:
+    """Batched, bounded-memory writer into a pgvector table over psycopg v3.
+
+    Peak memory is ~``batch_size`` rows, never O(corpus): rows and vectors are
+    consumed as streams and committed per batch, so a crashed ephemeral job
+    leaves a consistent committed prefix.
+    """
+
+    def __init__(self, config: PgVectorLoaderConfig) -> None:
+        self.config = config
+
+    def ensure_pgvector_extension(self) -> None:
+        """``CREATE EXTENSION IF NOT EXISTS vector`` — idempotent, opt-in."""
+        import psycopg
+
+        with psycopg.connect(self.config.dsn) as conn:
+            with conn.cursor() as cur:
+                cur.execute("CREATE EXTENSION IF NOT EXISTS vector")
+            conn.commit()
+
+    def load(self, rows: Iterable[dict], vectors: Iterable[list[float]]) -> int:
+        """Stream ``(row, vector)`` pairs into the target table in batches.
+
+        ``rows[i][col]`` supplies each non-vector column named in
+        ``config.columns``; ``vectors[i]`` supplies ``config.vector_column``.
+        Returns the total number of rows written.
+        """
+        import psycopg
+
+        cfg = self.config
+        pairs = zip(rows, vectors)
+        total = 0
+        with psycopg.connect(cfg.dsn) as conn:
+            for batch in _batched(iter(pairs), cfg.batch_size):
+                with conn.cursor() as cur:
+                    if cfg.use_copy:
+                        self._copy_batch(cur, batch)
+                    else:
+                        self._insert_batch(cur, batch)
+                conn.commit()
+                total += len(batch)
+        return total
+
+    @property
+    def _all_columns(self) -> list[str]:
+        return [*self.config.columns, self.config.vector_column]
+
+    def _copy_batch(self, cur, batch: list[tuple[dict, list[float]]]) -> None:
+        cfg = self.config
+        col_list = ", ".join(self._all_columns)
+        with cur.copy(f"COPY {cfg.table} ({col_list}) FROM STDIN") as copy:
+            for row, vector in batch:
+                values = [row[c] for c in cfg.columns]
+                values.append(_vector_literal(vector))
+                copy.write_row(values)
+
+    def _insert_batch(self, cur, batch: list[tuple[dict, list[float]]]) -> None:
+        cfg = self.config
+        col_list = ", ".join(self._all_columns)
+        placeholders = ", ".join(["%s"] * len(cfg.columns)) + ", %s::vector"
+        sql = f"INSERT INTO {cfg.table} ({col_list}) VALUES ({placeholders})"
+        params = [
+            [*(row[c] for c in cfg.columns), _vector_literal(vector)]
+            for row, vector in batch
+        ]
+        cur.executemany(sql, params)

--- a/ai-components/vector-store/src/rakam_systems_vectorstore/tests/test_gateway_embeddings.py
+++ b/ai-components/vector-store/src/rakam_systems_vectorstore/tests/test_gateway_embeddings.py
@@ -33,6 +33,61 @@ class _FakeEmbedder:
         return _FakeResult(self._embeddings)
 
 
+class _EchoEmbedder:
+    """Returns one index-encoding vector per input text, so batch splitting and
+    output order are both checkable. ``calls`` records each batch's size."""
+
+    def __init__(self, dim=4):
+        self._dim = dim
+        self.calls = []
+        self.async_calls = []
+
+    def _vectors(self, texts):
+        # Each text is "t{k}"; encode k in the first slot, pad to dim so the
+        # per-batch dim-guard stays satisfied.
+        return _FakeResult(
+            [[float(int(t[1:]))] + [0.0] * (self._dim - 1) for t in texts]
+        )
+
+    def embed_documents_sync(self, texts):
+        self.calls.append(len(texts))
+        return self._vectors(texts)
+
+    async def embed_documents(self, texts):
+        self.async_calls.append(len(texts))
+        return self._vectors(texts)
+
+
+class TestGatewayEmbeddingsBatching:
+    def test_batching_splits_into_expected_calls(self):
+        fake = _EchoEmbedder()
+        adapter = GatewayEmbeddings(fake, dim=4, batch_size=100)
+        adapter.run([f"t{k}" for k in range(250)])
+        assert fake.calls == [100, 100, 50]
+
+    def test_batching_preserves_order_and_count(self):
+        fake = _EchoEmbedder()
+        adapter = GatewayEmbeddings(fake, dim=4, batch_size=100)
+        out = adapter.run([f"t{k}" for k in range(250)])
+        assert len(out) == 250
+        assert [int(v[0]) for v in out] == list(range(250))  # vector k <- input k
+
+    def test_batch_size_none_is_single_call(self):
+        # Regression guard for the 2 existing consumers: default path is untouched.
+        fake = _EchoEmbedder()
+        adapter = GatewayEmbeddings(fake, dim=4)
+        adapter.run([f"t{k}" for k in range(250)])
+        assert fake.calls == [250]
+
+    def test_arun_batches_in_order(self):
+        fake = _EchoEmbedder()
+        adapter = GatewayEmbeddings(fake, dim=4, batch_size=100)
+        out = asyncio.run(adapter.arun([f"t{k}" for k in range(250)]))
+        assert fake.async_calls == [100, 100, 50]
+        assert [int(v[0]) for v in out] == list(range(250))
+        assert fake.calls == []  # async path only
+
+
 class TestGatewayEmbeddingsAdapter:
     def test_extracts_vectors_as_lists(self):
         fake = _FakeEmbedder([[0.1, 0.2, 0.3, 0.4], [0.5, 0.6, 0.7, 0.8]])
@@ -91,6 +146,11 @@ class TestBuildEmbedder:
         emb = build_embedder(EmbeddingRef(ref="openai:text-embedding-3-small", dim=1536))
         assert isinstance(emb, GatewayEmbeddings)
         assert emb._dim == 1536
+
+    def test_build_embedder_threads_batch_size(self):
+        cfg = EmbeddingRef(ref="openai:text-embedding-3-small", dim=1536)
+        assert build_embedder(cfg, batch_size=64)._batch_size == 64
+        assert build_embedder(cfg)._batch_size is None  # default unchanged
 
     def test_base_url_ref_returns_adapter(self):
         emb = build_embedder(

--- a/ai-components/vector-store/src/rakam_systems_vectorstore/tests/test_neo4j_loader.py
+++ b/ai-components/vector-store/src/rakam_systems_vectorstore/tests/test_neo4j_loader.py
@@ -1,0 +1,122 @@
+"""Tests for the generic Neo4j loader stub (T1.3b).
+
+Deferred-use (D13): a single connectivity+write integration test plus batching
+unit coverage is enough — do not over-invest. Integration tests gate on
+``NEO4J_TEST_URI`` / ``NEO4J_TEST_USER`` / ``NEO4J_TEST_PASSWORD`` and self-skip
+otherwise so collection succeeds without a Neo4j server. The batching and
+Cypher-guard tests are pure logic over a fake session and always run.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from rakam_systems_vectorstore.components.loader.neo4j_loader import (
+    Neo4jLoader,
+    Neo4jLoaderConfig,
+)
+
+_URI = os.environ.get("NEO4J_TEST_URI")
+_USER = os.environ.get("NEO4J_TEST_USER")
+_PASSWORD = os.environ.get("NEO4J_TEST_PASSWORD")
+_requires_db = pytest.mark.skipif(
+    not (_URI and _USER and _PASSWORD),
+    reason="NEO4J_TEST_* not set — no Neo4j server available",
+)
+
+
+class _FakeSession:
+    def __init__(self, recorder):
+        self._recorder = recorder
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def execute_write(self, fn):
+        # execute_write(lambda tx, b=batch: tx.run(cypher, rows=b)) — capture the
+        # batch the loader passed by running the callable against a fake tx.
+        return fn(_FakeTx(self._recorder))
+
+
+class _FakeTx:
+    def __init__(self, recorder):
+        self._recorder = recorder
+
+    def run(self, cypher, rows):
+        self._recorder.append(len(rows))
+        return _FakeCursor()
+
+
+class _FakeCursor:
+    def consume(self):
+        return None
+
+
+class _FakeDriver:
+    def __init__(self, recorder):
+        self._recorder = recorder
+
+    def session(self, database=None):
+        return _FakeSession(self._recorder)
+
+
+def _loader_with_fake_driver(recorder, batch_size):
+    loader = object.__new__(Neo4jLoader)
+    loader.config = Neo4jLoaderConfig(
+        uri="bolt://x", user="u", password="p", batch_size=batch_size
+    )
+    loader._driver = _FakeDriver(recorder)
+    return loader
+
+
+def test_load_rejects_cypher_without_rows_param():
+    recorder = []
+    loader = _loader_with_fake_driver(recorder, batch_size=10)
+    with pytest.raises(ValueError, match=r"\$rows"):
+        loader.load("MERGE (n:Node {id: 1})", rows=[{"id": 1}])
+
+
+def test_load_is_batched():
+    recorder = []
+    loader = _loader_with_fake_driver(recorder, batch_size=25)
+    written = loader.load(
+        "UNWIND $rows AS row MERGE (n:TestNode {id: row.id})",
+        rows=[{"id": i} for i in range(100)],
+    )
+    assert written == 100
+    assert recorder == [25, 25, 25, 25]  # 4 batched session writes
+
+
+@_requires_db
+class TestNeo4jLoaderIntegration:
+    def _loader(self):
+        return Neo4jLoader(
+            Neo4jLoaderConfig(uri=_URI, user=_USER, password=_PASSWORD)
+        )
+
+    def test_verify_connectivity_ok(self):
+        loader = self._loader()
+        try:
+            loader.verify_connectivity()  # no exception against live DB
+        finally:
+            loader.close()
+
+    def test_load_writes_nodes(self):
+        loader = self._loader()
+        try:
+            written = loader.load(
+                "UNWIND $rows AS row MERGE (n:TestNode {id: row.id}) SET n.name = row.name",
+                rows=[{"id": i, "name": f"n{i}"} for i in range(100)],
+            )
+            assert written == 100
+            with loader._driver.session(database=loader.config.database) as session:
+                count = session.run("MATCH (n:TestNode) RETURN count(n) AS c").single()["c"]
+                assert count == 100
+        finally:
+            with loader._driver.session(database=loader.config.database) as session:
+                session.run("MATCH (n:TestNode) DETACH DELETE n").consume()
+            loader.close()

--- a/ai-components/vector-store/src/rakam_systems_vectorstore/tests/test_pgvector_loader.py
+++ b/ai-components/vector-store/src/rakam_systems_vectorstore/tests/test_pgvector_loader.py
@@ -1,0 +1,148 @@
+"""Tests for the standalone psycopg pgvector loader (T1.3a).
+
+The DB write is a critical path, so it is exercised against a real
+``pgvector/pgvector`` Postgres (integration over mocks per rakam policy),
+gated on ``PGVECTOR_TEST_DSN``. Without that env var the integration tests
+self-skip so collection succeeds anywhere. The vector-literal formatter is
+pure logic and always runs.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+from rakam_systems_vectorstore.components.loader.pgvector_loader import (
+    PgVectorLoader,
+    PgVectorLoaderConfig,
+    _vector_literal,
+)
+
+_DSN = os.environ.get("PGVECTOR_TEST_DSN")
+_requires_db = pytest.mark.skipif(
+    not _DSN, reason="PGVECTOR_TEST_DSN not set — no pgvector Postgres available"
+)
+
+
+def test_vector_text_format():
+    assert _vector_literal([0.1, 0.2]) == "[0.1,0.2]"
+    assert _vector_literal([1.0, 2.0, 3.0, 4.0]) == "[1.0,2.0,3.0,4.0]"
+
+
+def test_public_symbols_importable_from_package_root():
+    import rakam_systems_vectorstore as vs
+
+    assert vs.PgVectorLoader is PgVectorLoader
+    assert vs.PgVectorLoaderConfig is PgVectorLoaderConfig
+
+
+@pytest.fixture
+def temp_table():
+    """Create a fresh vector(4) table; drop it on teardown."""
+    import psycopg
+
+    table = f"test_pgvec_{uuid.uuid4().hex[:12]}"
+    with psycopg.connect(_DSN) as conn:
+        with conn.cursor() as cur:
+            cur.execute("CREATE EXTENSION IF NOT EXISTS vector")
+            cur.execute(
+                f"CREATE TABLE {table} ("
+                "id serial PRIMARY KEY, content text, meta jsonb, embedding vector(4))"
+            )
+        conn.commit()
+    yield table
+    with psycopg.connect(_DSN) as conn:
+        with conn.cursor() as cur:
+            cur.execute(f"DROP TABLE IF EXISTS {table}")
+        conn.commit()
+
+
+def _fixture_rows_and_vectors(n: int):
+    rows = [{"content": f"doc-{i}", "meta": '{"i": %d}' % i} for i in range(n)]
+    vectors = [[float(i), float(i) + 0.1, float(i) + 0.2, float(i) + 0.3] for i in range(n)]
+    return rows, vectors
+
+
+@_requires_db
+class TestPgVectorLoaderIntegration:
+    def _config(self, table, **kw):
+        return PgVectorLoaderConfig(
+            dsn=_DSN, table=table, columns=["content", "meta"], **kw
+        )
+
+    def test_load_roundtrip(self, temp_table):
+        import psycopg
+
+        rows, vectors = _fixture_rows_and_vectors(1000)
+        loader = PgVectorLoader(self._config(temp_table, batch_size=100))
+        loader.load(rows, vectors)
+
+        with psycopg.connect(_DSN) as conn:
+            with conn.cursor() as cur:
+                cur.execute(f"SELECT count(*) FROM {temp_table}")
+                assert cur.fetchone()[0] == 1000
+                cur.execute(
+                    f"SELECT content, embedding FROM {temp_table} WHERE content = 'doc-7'"
+                )
+                content, embedding = cur.fetchone()
+                assert content == "doc-7"
+                assert str(embedding) == "[7,7.1,7.2,7.3]"
+
+    def test_load_returns_count(self, temp_table):
+        rows, vectors = _fixture_rows_and_vectors(250)
+        loader = PgVectorLoader(self._config(temp_table, batch_size=100))
+        assert loader.load(rows, vectors) == 250
+
+    def test_load_is_batched_not_whole_corpus(self, temp_table, monkeypatch):
+        rows, vectors = _fixture_rows_and_vectors(1000)
+        loader = PgVectorLoader(self._config(temp_table, batch_size=100))
+        calls = {"n": 0}
+        original = loader._copy_batch
+
+        def counting(cur, batch):
+            calls["n"] += 1
+            return original(cur, batch)
+
+        monkeypatch.setattr(loader, "_copy_batch", counting)
+        loader.load(rows, vectors)
+        assert calls["n"] == 10  # 1000 / 100, never one giant statement
+
+    def test_copy_and_executemany_parity(self, temp_table):
+        import psycopg
+
+        rows, vectors = _fixture_rows_and_vectors(200)
+        PgVectorLoader(self._config(temp_table, use_copy=True)).load(rows, vectors)
+
+        other = f"{temp_table}_em"
+        with psycopg.connect(_DSN) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"CREATE TABLE {other} (LIKE {temp_table} INCLUDING ALL)"
+                )
+            conn.commit()
+        try:
+            rows2, vectors2 = _fixture_rows_and_vectors(200)
+            PgVectorLoader(self._config(other, use_copy=False)).load(rows2, vectors2)
+            with psycopg.connect(_DSN) as conn:
+                with conn.cursor() as cur:
+                    cur.execute(f"SELECT count(*) FROM {temp_table}")
+                    copy_count = cur.fetchone()[0]
+                    cur.execute(f"SELECT count(*) FROM {other}")
+                    em_count = cur.fetchone()[0]
+                    assert copy_count == em_count == 200
+                    cur.execute(
+                        f"SELECT c.embedding = e.embedding "
+                        f"FROM {temp_table} c JOIN {other} e USING (content)"
+                    )
+                    assert all(r[0] for r in cur.fetchall())
+        finally:
+            with psycopg.connect(_DSN) as conn:
+                with conn.cursor() as cur:
+                    cur.execute(f"DROP TABLE IF EXISTS {other}")
+                conn.commit()
+
+    def test_ensure_pgvector_extension_idempotent(self, temp_table):
+        loader = PgVectorLoader(self._config(temp_table))
+        loader.ensure_pgvector_extension()
+        loader.ensure_pgvector_extension()  # no error on second call

--- a/ai-components/vector-store/uv.lock
+++ b/ai-components/vector-store/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14' and python_full_version < '4'",
@@ -2711,6 +2711,18 @@ wheels = [
 ]
 
 [[package]]
+name = "neo4j"
+version = "5.28.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/aa/83baca8f9e5e5ba1a00722067a4bf3c088c5c02019a7b485e94c8cf05d39/neo4j-5.28.4.tar.gz", hash = "sha256:4a2d8d6eb8c2da0bc87a30e96e2c179fbc0045665626482901ca3dcc9c2b1811", size = 232608, upload-time = "2026-05-04T08:00:55.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/fd/d46f29f4089a00a7d4894f5e1739288c2a42622b72ea7161a226b73ff4fa/neo4j-5.28.4-py3-none-any.whl", hash = "sha256:ba87c423fd2a1fbe6a116c47ac96cfbe7d8c419d24d2f5611e5674283dddf7b9", size = 313927, upload-time = "2026-05-04T08:00:52.005Z" },
+]
+
+[[package]]
 name = "networkx"
 version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3719,6 +3731,86 @@ wheels = [
 ]
 
 [[package]]
+name = "psycopg"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/2f/cb91e5502ec9de1de6f1b76cfbf69531932725361168bb06963620c77e2e/psycopg-3.3.4.tar.gz", hash = "sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc", size = 165799, upload-time = "2026-05-01T23:31:55.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e0/7b3dee031daae7743609ce3c746565d4a3ed7c2c186479eb48e34e838c64/psycopg-3.3.4-py3-none-any.whl", hash = "sha256:b6bbc25ccf05c8fad3b061d9db2ef0909a555171b84b07f29458a447253d679a", size = 213001, upload-time = "2026-05-01T23:20:50.816Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/bf/70d8a60488f9955cbbcd538beae44d56bb2f1d19e673b72788f2d343ff55/psycopg_binary-3.3.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b7bfff1ca23732b488cbca3076fc11bc98d520ee122514fdb17a8e20d3338f5a", size = 4609750, upload-time = "2026-05-01T23:24:20.06Z" },
+    { url = "https://files.pythonhosted.org/packages/db/b0/29e98ba210c9dbc75a6dc91e3f99b9e06ea901a62ca95804e02a1ae13e6b/psycopg_binary-3.3.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:32a6fbf8481e3a370d0d72b860d35948a693cb01281da217f7b2f307636e591a", size = 4676700, upload-time = "2026-05-01T23:25:21.727Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ab/3df087b3c12bf74e47c08204172b2fabb5a144679110d5c7ad12d9201323/psycopg_binary-3.3.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:bdef84570ebbce1d42b4e7ea952d21c414c5f118ad02fee00c5625f35e134429", size = 5496319, upload-time = "2026-05-01T23:25:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/87/9a/f088207b4cd6772f9e0d8a91807e79fa2458d4eb9eb1ae406c68415f2bec/psycopg_binary-3.3.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fa1cbc10768a796c96d3243656016bf4e337c81c71097270bb7b0ad6210d9765", size = 5171906, upload-time = "2026-05-01T23:25:34.004Z" },
+    { url = "https://files.pythonhosted.org/packages/48/45/4523a857f253871d75c22e1c2e79fd47e599e736bcba1bad58d83e24be02/psycopg_binary-3.3.4-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cf7f73a4a792bc5db58a4b385d8a1467e8d468f7548702fb0ed1e9b7501b1c13", size = 6762621, upload-time = "2026-05-01T23:25:41.392Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/d1/925bf776503345bef428e6c45fb017d0139ddbe0e211814b585c4253dca8/psycopg_binary-3.3.4-cp310-cp310-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d7b4d40c153fa352ab3cca530f3a0baedf7621b2ebcbd7f084009522c21788fc", size = 5006319, upload-time = "2026-05-01T23:25:51.419Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/aa/99727337206fbba357ca084bf4ea8b29dc986f61842a2685859af61416db/psycopg_binary-3.3.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f9b1c2533af01cd7648378599f82b0b8ae32f293296e6eec5753a625bc97ef28", size = 4535388, upload-time = "2026-05-01T23:25:57.957Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/a4/567ba2c37d19d8c2f63d836385dfd2495aa5897bbee6cfab104d9ee58624/psycopg_binary-3.3.4-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:ad3bc94054876155549fdaedf4a46d1ec69d39a5bcee377148afe498e84c4b8e", size = 4224544, upload-time = "2026-05-01T23:26:03.832Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/23/86457f5a82731685d7701de7bfaa5eb783dd1fecbf875321897d9d9ce33a/psycopg_binary-3.3.4-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:eb4eed2079c01a4850bf467deacfab56d356d4225040170af03dc9958321242d", size = 3956282, upload-time = "2026-05-01T23:26:09.983Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/d8/249456df16d47de082abd9b73bce8ccdeb0293eb12e590f9150c7cbdb788/psycopg_binary-3.3.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f80e3f2b5331dbbf0901bcb658056c03eeb2c1ef31d774afb0d61598b242e744", size = 4261736, upload-time = "2026-05-01T23:26:16.798Z" },
+    { url = "https://files.pythonhosted.org/packages/15/6b/c4abe228acafd8a385c1fb615d4f1e3c9b8ad7a4e4f0e84118ba3ffeed9c/psycopg_binary-3.3.4-cp310-cp310-win_amd64.whl", hash = "sha256:574ea21a9651958f1535c5a1c649c7409e9168bcbffa29a3f2f961f58b322949", size = 3570620, upload-time = "2026-05-01T23:26:22.655Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/82/df3312c0ca083d5b43b352f27d4dd8b1e614bd334473074715d9e0000da4/psycopg_binary-3.3.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:612a627d733f695b1de1f9b4bd511c15f999a5d8b915d444bbd7dd71cf3370da", size = 4609813, upload-time = "2026-05-01T23:26:30.612Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/b5/d74d542458d3e8ac0571d8a88f57ca369999b9a82f4fa528052d0d7d3e4c/psycopg_binary-3.3.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:13a7f380824c35896dcac7fe0f61440f7ca49d6dc73f3c13a9a4471e6a3b302e", size = 4676799, upload-time = "2026-05-01T23:26:38.475Z" },
+    { url = "https://files.pythonhosted.org/packages/09/67/06bab9c60671999f4c6ceff1b334f3ac1f9fc5789eb467c714623ea21de9/psycopg_binary-3.3.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:276904e3452d6a23d474ef9a21eee19f20eed3d53ddd2576af033827e0ba0992", size = 5497050, upload-time = "2026-05-01T23:26:47.061Z" },
+    { url = "https://files.pythonhosted.org/packages/72/9b/023433e2b20f970de1e22d29132a95281277646da0b2e2879dd4ee94b8c1/psycopg_binary-3.3.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ab8cca8ef8fb1ccf5b048ae5bd78ba55b9e4b5d472e3ce5ca39ff4d2a9c249e4", size = 5172428, upload-time = "2026-05-01T23:26:56.708Z" },
+    { url = "https://files.pythonhosted.org/packages/08/cd/ae16da8fde228a38b2fe9269bbc13cf89e0186173f2265600f02d6a71e64/psycopg_binary-3.3.4-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7465bfe6087d2d5b42d4c53b9b11ca9f218e477317a4a162a10e3c19e984ba8e", size = 6762746, upload-time = "2026-05-01T23:27:07.023Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/81/0ba09fa5f5f88779093a2541a8e02489825721f258ab88058b11d68b3eb5/psycopg_binary-3.3.4-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:22cdbf5f91ef7bb91fe0c5757e1962d3127a8010256eefd9c61fcaf441802097", size = 5006033, upload-time = "2026-05-01T23:27:12.221Z" },
+    { url = "https://files.pythonhosted.org/packages/73/6a/629136040cc3497adb442a305710b5913f2a754d4630fc3d3717c4c0df65/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e2631da29253a98bd496e6c4813b24e09a4fe3fb2a9e88513305d6f8747cce95", size = 4534175, upload-time = "2026-05-01T23:27:18.248Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/32/1027f843c6dc2d5d51960ee62cc0c2cf755a4c39455aff1371173edbef7d/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:7f7668f30b9dd5163197e5cbf4e0efd54e00f0a859cc566ce56cfc31f4054839", size = 4224203, upload-time = "2026-05-01T23:27:24.3Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e1/380a724d9093c74adb14d4fce920ea8327838abb61f760b1448586b14a8e/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:cffc3408d77a27973f33e5d909b624cce683db5fc25964b02fe0aae7886c1007", size = 3954509, upload-time = "2026-05-01T23:27:30.815Z" },
+    { url = "https://files.pythonhosted.org/packages/db/cd/895893ae575a09c97ccfd5def070d88993d955ef34df45a881fd5ff506d6/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0579252a1202cd73e4da137a1426e2dae993ae44e757605344282af3a082848c", size = 4259551, upload-time = "2026-05-01T23:27:38.828Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/c6/2330a20794e37a3ec609ef2fd8522919ec7a4395a1abf979a8e2d1775cd5/psycopg_binary-3.3.4-cp311-cp311-win_amd64.whl", hash = "sha256:41f2ec0fea529832982bcb6c9415de3c86264ebe562b77a467c0fbcd7efbba8d", size = 3572054, upload-time = "2026-05-01T23:27:45.455Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7d/03818e13ba7f36de93573c93ee3482006d3dfa8b0f8d28df511bad0a1a92/psycopg_binary-3.3.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5ab28a2a7649df3b72e6b674b4c190e448e8e77cf496a65bd846472048de2089", size = 4591122, upload-time = "2026-05-01T23:27:56.162Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b9/11b341edf8d54e2694726b273fe9652b254d989f4f63e3ac6816ad6b55f4/psycopg_binary-3.3.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6402a9d8146cf4b3974ded3fd28a971e83dc6a0333eb7822524a3aa20b546578", size = 4669943, upload-time = "2026-05-01T23:28:04.522Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/18/4665bacd65e7865b4372fcd8abb8b9186ada4b0025f8c2ca691b364a556c/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:580ae30a5f95ccd90008ec697d3ed6a4a2047a516407ad904283fa42086936e9", size = 5469697, upload-time = "2026-05-01T23:28:11.337Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b1/b83136c6e510593d9b0c759ba5384337bc4ad82d19fda675adc4b2703c84/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e7510c37550f91a187e3660a8cc50d4b760f8c3b8b2f89ebc5698cd2c7f2c85d", size = 5152995, upload-time = "2026-05-01T23:28:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/67/8d/a9821e2a648afe6091989929982a3b0f00b2631a859cb81379728f08fb75/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77df19583501ea288eaf15ac0fe7ad01e6d8091a91d5c41df5c718f307d8e31b", size = 6738180, upload-time = "2026-05-01T23:28:30.654Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/58/2e349e8d23905dc2317b80ac65f48fb6f821a4777a4e994a60da91c4850f/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:018fbed325936da502feb546642c982dcc4b9ffdea32dfef78dbf3b7f7ad4070", size = 4978828, upload-time = "2026-05-01T23:28:37.277Z" },
+    { url = "https://files.pythonhosted.org/packages/45/48/57b00d03b4721878326122a1f1e6b0a90b85bcaec56b5b2f8ea6cfa45235/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:17a21953a9e5ff3a16dab692625a3676e2f101db5e40072f39dbee2250194d68", size = 4509757, upload-time = "2026-05-01T23:28:43.078Z" },
+    { url = "https://files.pythonhosted.org/packages/25/37/33b47d8c007df69aec500df5889767c4d313748e8e9e27a2fef8a6dabcee/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:eb05ee1c2b817d27c537333224c9e83c7afb86fe7296ba970990068baf819b16", size = 4190546, upload-time = "2026-05-01T23:28:50.016Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/c6/32b0835dbc2122617902b649d76a91c1e75406e76bf3d595b0c3bb5ffad6/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:773d573e11f437ce0bdb95b7c18dc58390494f96d43f8b45b9760436114f7652", size = 3926197, upload-time = "2026-05-01T23:28:55.55Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/68/d190ef0c0c5b16ded07831dabc8ddd412f4cdab07ec6e30ed38d9bda0e1f/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:71e55ccbdfae79a2ed9c6369c3008a3025817ff9d7e27b32a2d84e2a4267e66e", size = 4236627, upload-time = "2026-05-01T23:29:05.336Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8f/81dcbc2e8454b74d14881275ea45f00791052dac531a9fa8be1730d1685b/psycopg_binary-3.3.4-cp312-cp312-win_amd64.whl", hash = "sha256:494ca54901be8cf9eb7e02c25b731f2317c378efa44f43e8f9bd0e1184ae7be4", size = 3560782, upload-time = "2026-05-01T23:29:11.967Z" },
+    { url = "https://files.pythonhosted.org/packages/09/43/13e9c406fbbf354580476e248a16b64802a376873ebe6339e30bb655572d/psycopg_binary-3.3.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fbd1d4ed566895ad2d3bf4ddfd8bae90026930ddf29df3b9d91d32c8c47866a7", size = 4590377, upload-time = "2026-05-01T23:29:18.782Z" },
+    { url = "https://files.pythonhosted.org/packages/22/be/2923cd7c3683e7afdecf4f10796a18de02f5c5ddc0969aa2ad0a8cdd3bbd/psycopg_binary-3.3.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:75a9067e236f9b9ae3535b66fe99bddb33d39c0de10112e49b9ab11eee53dc31", size = 4669023, upload-time = "2026-05-01T23:29:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/96/a0/2c913d6fe13d6a8bd13597d36739bf47af063ad9399e402cfecab16f3c1e/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:b56b603ebcea8aa10b46228b8410ba7f13e7c2ee54389d4d9be0927fd8ce2a70", size = 5467423, upload-time = "2026-05-01T23:29:33.416Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/38/205d10bc1ad0df4a21c5c51659126bd3ea0ef98fcad1e852f78c249bb9c3/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c677c4ad433cb7150c8cd304a0769ae3bcfbe5ea0676eb53faa7b1443b16d0d3", size = 5151137, upload-time = "2026-05-01T23:29:42.013Z" },
+    { url = "https://files.pythonhosted.org/packages/36/fc/f0381ddcd45eff3bb70dbca6823a996048d7f507b2ec3fc92c6fabc0fe87/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26df2717e59c0473e4465a97dfb1b7afebaa479277870fd5784d1436470db47c", size = 6736671, upload-time = "2026-05-01T23:29:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/95/40/fa545ae152c24327651e5624e4902121e808270be36c10b12e9939be09bc/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1dc1f79fd16bb1f3f4421417a514607539f17804d95c7ed617265369d1981cae", size = 4979601, upload-time = "2026-05-01T23:29:56.961Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e4/2f8a47ee97f90cd2b933d0463081d35631ff419de2b8c984a5f369857de0/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:136f199a407b5348b9b857c504aff60c77622a28482e7195839ce1b51238c4cc", size = 4510513, upload-time = "2026-05-01T23:30:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0e/94e842ff4a7f98ed162580ca2e8b8864b28c1e0350f2443f8ee47f821167/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b6f5a29e9c775b9f12a1a717aa7a2c80f9e1db6f27ba44a5b59c80ac61d2ffcf", size = 4187243, upload-time = "2026-05-01T23:30:15.352Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/83/fc6c174b672e29b7de996ea77b6cbddf46c891751c3355f6974292baa6b4/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:ee17a2cf4943cde261adfad1bbc5bf38d6b3776d7afff74c7cabcbeaeb08c260", size = 3927347, upload-time = "2026-05-01T23:30:21.186Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/65/768364d4a97a15b1a7f47ba52688c1686f22941d8332a8398cefc468e25f/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c4ab71be17bdca30cb34c34c4e1496e2f5d6f20c199c12bad226070b22ef9bf", size = 4236393, upload-time = "2026-05-01T23:30:26.211Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3b/218efbc9e645becd80cdf651acda05f85cfe546b7a9c0458c7cbc8fe1f74/psycopg_binary-3.3.4-cp313-cp313-win_amd64.whl", hash = "sha256:dbfdb9b6cc79f31104a7b162a2b921b765fcc62af6c00540a167a8de47e4ed38", size = 3564592, upload-time = "2026-05-01T23:30:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a6/828c9185701dab71b234c2a76c38a08b098ebfec5020716b4e93807492b5/psycopg_binary-3.3.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:28b7398fdd19db3232c884fb24550bdfe951221f510e195e233299e4c9b78f97", size = 4607292, upload-time = "2026-05-01T23:30:38.962Z" },
+    { url = "https://files.pythonhosted.org/packages/92/58/5b40dbc9d839045c9dae956960e4fb6d20bcabe6c59a2aa34fc3a371913f/psycopg_binary-3.3.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1fbaa292a3c8bb61b45df1ad3da1908ccee7cb889db9425e3557d9e34e2a4829", size = 4687023, upload-time = "2026-05-01T23:30:47.227Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a9/793f0ac107a9003b48441d0d1f9f616d96e0f37458dd8dc12528ceff55fb/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94596f9e7633ee3f6440711d43bb70aa31cc0a46a900ab8b4201a366ace5c9e7", size = 5486985, upload-time = "2026-05-01T23:30:55.517Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/26/42e8533497e2592334f68ec529cf5f840f7fa4e99575a4bb61aa184dbfbf/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8c0056529e68dbe9184cd4019a1f3d8f3a4ead2f6fc7a5afcf27d3314edd1277", size = 5168745, upload-time = "2026-05-01T23:31:01.904Z" },
+    { url = "https://files.pythonhosted.org/packages/15/af/b7151776cc08d5935d45c833ec818a9beb417cf7c08239af1aafbdae78ee/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c09aad7051326e7603c14e50636db9c01f78272dc54b3accff03d46370461e6", size = 6761486, upload-time = "2026-05-01T23:31:14.511Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ed/c92533b9124712d592cbf1cd6c76da933a2e0acea81dfe1fbe7e735f0cff/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:514404ed543efd620c85602b747df2a23cf1241b4067199e1a66f2d2757aaa41", size = 4997427, upload-time = "2026-05-01T23:31:20.901Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/ccadfd0de416aa188356daa199453af24087b042e296088706d190ae0295/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:46893c26858be12cc49ca4226ed6a60b4bfccadd946b3bebb783a60b38788228", size = 4533549, upload-time = "2026-05-01T23:31:26.204Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a0/c8f43cee36386f7bc891ab41a9d31ea07cf9826038e732da79f26b1e5f34/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:df1d567fc430f6df15c9fcf67d87685fc49bdb325adc0db5af1adfb2f44eb5c9", size = 4210256, upload-time = "2026-05-01T23:31:33.884Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/2c/c1547871be3790676e8868b38655496422f94f0978dfb66b74bdba2f1676/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:6b9016b1714da4dd5ecaaa75b82098aa5a0b87854ce9b092e21c27c4ae23e014", size = 3946204, upload-time = "2026-05-01T23:31:39.626Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b1/f6670f00fa7ea601584623f6c11602ab92117d83eaff885e0210f6de7418/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:47c656a8a7ba6eb0cff1801a4caaa9c8bdc12d03080e273aff1c8ac39971a77e", size = 4255811, upload-time = "2026-05-01T23:31:44.986Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e6/5fff07a70d1f945ed90ae131c3bd76cab32beff7c58c6db15ad5820b6d1f/psycopg_binary-3.3.4-cp314-cp314-win_amd64.whl", hash = "sha256:c37e024c07308cd06cf3ec51bfd0e7f6157585a4d84d1bce4a7f5f7913719bf8", size = 3666849, upload-time = "2026-05-01T23:31:51.165Z" },
+]
+
+[[package]]
 name = "psycopg2-binary"
 version = "2.9.11"
 source = { registry = "https://pypi.org/simple" }
@@ -4696,25 +4788,14 @@ wheels = [
 [[package]]
 name = "rakam-systems-core"
 version = "0.1.5"
-source = { editable = "../../core" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "pydantic" },
-    { name = "pyyaml" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "build", specifier = ">=1.2.2.post1" },
-    { name = "pytest", specifier = ">=8.3.5" },
-    { name = "pytest-asyncio", specifier = ">=0.24.0" },
-    { name = "pytest-cov", specifier = ">=5.0.0" },
-    { name = "twine", specifier = ">=6.1.0" },
+sdist = { url = "https://files.pythonhosted.org/packages/ba/15/d2a4790c71c60f690cd224f160d75c954df284d98e888bb82afc8a448d96/rakam_systems_core-0.1.5.tar.gz", hash = "sha256:efeb2fabbfe590c1f36939ab09813157b7fee1745abb3329c34e0945064b3f27", size = 45443, upload-time = "2026-07-02T15:04:05.438Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/07/46084f17d47268626c4248cd0d12f4c69b2c52c0f5091abb3dfc4632233f/rakam_systems_core-0.1.5-py3-none-any.whl", hash = "sha256:1441fc1fbe22df5895cf381d075fe6be97ce69e53fe040c55813d0a090d95b8f", size = 62524, upload-time = "2026-07-02T15:04:03.804Z" },
 ]
 
 [[package]]
@@ -4735,7 +4816,7 @@ wheels = [
 
 [[package]]
 name = "rakam-systems-vectorstore"
-version = "0.1.6"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -4780,6 +4861,10 @@ dev = [
 faiss = [
     { name = "faiss-cpu" },
 ]
+ingestion = [
+    { name = "neo4j" },
+    { name = "psycopg", extra = ["binary"] },
+]
 loaders = [
     { name = "beautifulsoup4" },
     { name = "chonkie" },
@@ -4812,14 +4897,16 @@ requires-dist = [
     { name = "django", marker = "extra == 'postgres'", specifier = ">=4.0.0,<6.0.0" },
     { name = "docling", marker = "extra == 'loaders'", specifier = "==2.62.0" },
     { name = "faiss-cpu", marker = "extra == 'faiss'", specifier = ">=1.12.0" },
+    { name = "neo4j", marker = "extra == 'ingestion'", specifier = ">=5.0,<6.0" },
     { name = "numpy", specifier = ">=1.24.0,<3.0.0" },
     { name = "odfpy", marker = "extra == 'loaders'", specifier = "==1.4.1" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.0.0" },
     { name = "pgvector", marker = "extra == 'postgres'", specifier = ">=0.3.0,<1.0.0" },
+    { name = "psycopg", extras = ["binary"], marker = "extra == 'ingestion'", specifier = ">=3.1,<4.0" },
     { name = "psycopg2-binary", marker = "extra == 'postgres'", specifier = ">=2.9.9,<3.0.0" },
     { name = "pydantic-ai", specifier = ">=1.11.0,<2.0.0" },
     { name = "pymupdf", marker = "extra == 'loaders'", specifier = ">=1.24.0" },
-    { name = "pymupdf4llm", marker = "extra == 'loaders'", specifier = ">=0.0.17" },
+    { name = "pymupdf4llm", marker = "extra == 'loaders'", specifier = ">=0.0.17,<1.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
@@ -4827,7 +4914,7 @@ requires-dist = [
     { name = "python-docx", marker = "extra == 'loaders'", specifier = ">=1.2.0" },
     { name = "python-magic", marker = "extra == 'loaders'", specifier = ">=0.4.27" },
     { name = "pyyaml", specifier = ">=6.0,<7.0" },
-    { name = "rakam-systems-core", editable = "../../core" },
+    { name = "rakam-systems-core", specifier = ">=0.1.5" },
     { name = "rakam-systems-tools", specifier = ">=0.2.2" },
     { name = "rakam-systems-vectorstore", extras = ["cohere"], marker = "extra == 'all'" },
     { name = "rakam-systems-vectorstore", extras = ["faiss"], marker = "extra == 'all'" },
@@ -4840,7 +4927,7 @@ requires-dist = [
     { name = "torch", marker = "extra == 'local-embeddings'", specifier = ">=2.0.0" },
     { name = "tqdm", specifier = ">=4.66.0,<5.0.0" },
 ]
-provides-extras = ["postgres", "faiss", "local-embeddings", "openai", "cohere", "loaders", "dev", "all"]
+provides-extras = ["postgres", "ingestion", "faiss", "local-embeddings", "openai", "cohere", "loaders", "dev", "all"]
 
 [[package]]
 name = "rapidocr"


### PR DESCRIPTION
## Summary
Capability-layer primitives for the data-ingestion redesign (Notion §3.0 / D14 — these speak only universal nouns, no pipeline/ticket concepts). Additive to `rakam-systems-vectorstore`; version bumped **0.1.6 → 0.2.0**.

- **T1.3a** — standalone psycopg-v3 `PgVectorLoader` (batched COPY/insert given columns+rows). The existing `ConfigurablePgVectorStore`/`PgVectorStore` are Django-ORM-bound and cannot run in the Django-less ephemeral ingestion job, so this reuses their SQL shape over plain psycopg. Added behind a new optional `ingestion` extra.
- **T1.3b** — generic `Neo4jLoader` stub (batched `UNWIND $rows`), the deferred graph-sink seam (D13, no V1 consumer).
- **T1.4** — batched embedder: extends `GatewayEmbeddings`/`build_embedder` with an **additive `batch_size=None` kwarg** (default preserves single-call behavior); order-preserving.

## Test plan
- `cd ai-components/vector-store && uv run pytest src/rakam_systems_vectorstore/tests/test_pgvector_loader.py test_neo4j_loader.py test_gateway_embeddings.py -v`
- T1.4: **15 pass** (incl. `test_batch_size_none_is_single_call` regression guard). T1.3a/b: unit pass; pgvector/Neo4j integration tests self-skip without `PGVECTOR_TEST_DSN`/`NEO4J_TEST_*` (CI runs them where infra exists).

## Impact
- **Additive, zero existing-symbol changes** → blast radius nil until the engine adopts them.
- `build_embedder` is consumed by `ots-graph-generation-service` + `ots-ticket-service` — change is additive-kwarg-only (default None), so no consumer break.
- OQ4: new psycopg-v3 `ingestion` extra is a separate distribution from the Django stores' psycopg2 and lives behind an optional extra — **no version clash** (verified via `find_dependents`).
- **Release held** — do not tag until the redesign GO gate.

Tickets: `specs/data-ingestion-redesign/tickets/T1.3a,T1.3b,T1.4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)