### PR TITLE
feat(tools): streaming/range S3 read + NDJSON helper (T1.1, T1.2)

### DIFF
--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "rakam-systems-tools"
-version = "0.2.2"
+version = "0.3.0"
 description = "Evaluation Framework Tools"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "rakam-systems-tools"
-version = "0.3.0"
+version = "0.2.2"
 description = "Evaluation Framework Tools"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tools/src/rakam_systems_tools/tests/test_ndjson.py
+++ b/tools/src/rakam_systems_tools/tests/test_ndjson.py
@@ -1,0 +1,175 @@
+"""
+Tests for the NDJSON streaming helper (T1.2).
+
+``iter_ndjson_lines`` is pure logic — unit-tested here with hand-built byte
+iterables, no S3, no network. The ``stream_ndjson_from_s3`` roundtrip is a
+critical-path integration test that skips cleanly without S3 credentials
+(same pattern as test_s3.py).
+"""
+import json
+import os
+from datetime import datetime
+
+import pytest
+
+from rakam_systems_tools.utils.ndjson import (
+    iter_ndjson_lines,
+    stream_ndjson_from_s3,
+)
+
+# U+2028 (line separator) and U+2085 — str.splitlines() breaks on these, the
+# byte-level split must not.
+LS = " "
+U2085 = "₅"
+
+
+# ---- iter_ndjson_lines: pure unit tests ----
+
+def test_splits_on_newline_byte_only():
+    """A record whose string value embeds \\r, U+2028 and U+2085 survives whole.
+
+    Regression guard for the str.splitlines() corruption bug.
+    """
+    value = f"line one\rline two{LS}line three{U2085}end"
+    record = {"body": value}
+    data = (json.dumps(record) + "\n").encode("utf-8")
+
+    out = list(iter_ndjson_lines([data]))
+
+    assert len(out) == 1
+    line, _ = out[0]
+    assert json.loads(line.decode("utf-8"))["body"] == value
+
+
+def test_partial_line_buffered_across_chunks():
+    """One logical record split across three arbitrary byte boundaries."""
+    record = {"body": f"a{LS}b\rc", "n": 42}
+    data = (json.dumps(record) + "\n").encode("utf-8")
+    chunks = [data[:5], data[5:11], data[11:]]
+
+    out = list(iter_ndjson_lines(chunks))
+
+    assert len(out) == 1
+    line, _ = out[0]
+    assert json.loads(line.decode("utf-8")) == record
+
+
+def test_end_offset_is_absolute_past_newline():
+    """end_offset equals cumulative byte length including each newline."""
+    r1 = b'{"a":1}'
+    r2 = b'{"b":2}'
+    r3 = b'{"c":3}'
+    data = r1 + b"\n" + r2 + b"\n" + r3 + b"\n"
+
+    out = list(iter_ndjson_lines([data]))
+
+    offsets = [off for _, off in out]
+    assert offsets == [
+        len(r1) + 1,
+        len(r1) + 1 + len(r2) + 1,
+        len(r1) + 1 + len(r2) + 1 + len(r3) + 1,
+    ]
+    assert offsets[-1] == len(data)
+
+
+def test_no_trailing_newline_yields_last_record():
+    """Trailing bytes without a final newline are still yielded."""
+    r1 = b'{"a":1}'
+    r2 = b'{"b":2}'
+    data = r1 + b"\n" + r2  # no final newline
+
+    out = list(iter_ndjson_lines([data]))
+
+    assert len(out) == 2
+    assert out[1][0] == r2
+    assert out[1][1] == len(data)
+
+
+def test_blank_lines_skipped():
+    """Embedded blank lines (\\n\\n) are not yielded, offsets stay absolute."""
+    r1 = b'{"a":1}'
+    r2 = b'{"b":2}'
+    data = r1 + b"\n\n" + r2 + b"\n"
+
+    out = list(iter_ndjson_lines([data]))
+
+    lines = [line for line, _ in out]
+    assert lines == [r1, r2]
+    # r2's end_offset still counts the skipped blank line's newline.
+    assert out[1][1] == len(data)
+
+
+def test_skip_partial_first_line():
+    """skip_partial_first_line drops the head; remaining offsets stay absolute."""
+    partial = b'artial":1}'  # tail of a record split by a mid-object range read
+    r2 = b'{"b":2}'
+    r3 = b'{"c":3}'
+    data = partial + b"\n" + r2 + b"\n" + r3 + b"\n"
+    start = 100  # a ranged read began at byte 100
+
+    out = list(
+        iter_ndjson_lines(
+            [data], start_offset=start, skip_partial_first_line=True
+        )
+    )
+
+    lines = [line for line, _ in out]
+    assert lines == [r2, r3]
+    assert out[0][1] == start + len(partial) + 1 + len(r2) + 1
+    assert out[1][1] == start + len(data)
+
+
+# ---- stream_ndjson_from_s3: integration (skips without creds) ----
+
+ONE_MIB = 1024 * 1024
+TEST_PREFIX = "pytest_s3_test/"
+
+
+def _s3_config_ok() -> bool:
+    return bool(
+        os.getenv("S3_ACCESS_KEY")
+        and os.getenv("S3_SECRET_KEY")
+        and os.getenv("S3_BUCKET_NAME")
+    )
+
+
+@pytest.fixture(scope="module")
+def s3_ndjson_object():
+    """Upload a >1 MiB NDJSON object; yield (key, records, size)."""
+    if not _s3_config_ok():
+        pytest.skip(
+            "S3 tests require S3_ACCESS_KEY, S3_SECRET_KEY, S3_BUCKET_NAME"
+        )
+    from rakam_systems_tools.utils.s3 import s3
+
+    # Enough records with a fat body to exceed 1 MiB and cross chunk boundaries.
+    records = [
+        {"id": i, "body": f"line{i}\rembedded{LS}sep{U2085} " + "x" * 200}
+        for i in range(6000)
+    ]
+    payload = "".join(json.dumps(r) + "\n" for r in records).encode("utf-8")
+    assert len(payload) > ONE_MIB
+
+    key = f"{TEST_PREFIX}ndjson_{datetime.now().strftime('%Y%m%d_%H%M%S')}.ndjson"
+    s3.upload_file(key=key, content=payload,
+                   content_type="application/x-ndjson")
+    yield key, records, len(payload)
+    s3.delete_file(key)
+
+
+def test_stream_ndjson_from_s3_roundtrip_and_resume(s3_ndjson_object):
+    """Full stream matches source; a mid-record resume lands on a clean record."""
+    key, records, size = s3_ndjson_object
+
+    streamed = list(stream_ndjson_from_s3(key))
+    assert [r for r, _ in streamed] == records
+    assert streamed[-1][1] == size
+
+    # Resume from a byte offset that lands inside some record.
+    mid = size // 2
+    resumed = list(stream_ndjson_from_s3(key, start_offset=mid))
+    # It must skip the shattered partial and start on the next whole record.
+    assert resumed[0][0] in records
+    resume_index = records.index(resumed[0][0])
+    assert [r for r, _ in resumed] == records[resume_index:]
+    assert resumed[-1][1] == size

--- a/tools/src/rakam_systems_tools/tests/test_s3.py
+++ b/tools/src/rakam_systems_tools/tests/test_s3.py
@@ -154,3 +154,53 @@ def test_upload_binary(s3_require_config, s3_test_key):
     out = s3.download_file(key=key_bin)
     assert out == data
     s3.delete_file(key_bin)
+
+
+# ---- Streaming / range read (T1.1) ----
+
+ONE_MIB = 1024 * 1024
+
+
+@pytest.fixture(scope="module")
+def s3_stream_object(s3_require_config):
+    """Upload a ~3 MiB object once for the streaming tests; yield (key, bytes)."""
+    key = f"{TEST_PREFIX}stream_{datetime.now().strftime('%Y%m%d_%H%M%S')}.bin"
+    data = os.urandom(3 * ONE_MIB + 123)  # not a whole number of chunks
+    s3.upload_file(key=key, content=data,
+                   content_type="application/octet-stream")
+    yield key, data
+    s3.delete_file(key)
+
+
+def test_stream_file_roundtrip_matches_download_file(s3_stream_object):
+    """Concatenated stream equals the one-shot download_file bytes."""
+    key, data = s3_stream_object
+    assert b"".join(s3.stream_file(key)) == s3.download_file(key)
+
+
+def test_stream_file_chunks_are_bounded(s3_stream_object):
+    """Every chunk is <= chunk_size and there is more than one chunk."""
+    key, _ = s3_stream_object
+    chunks = list(s3.stream_file(key, chunk_size=ONE_MIB))
+    assert len(chunks) > 1
+    for chunk in chunks:
+        assert len(chunk) <= ONE_MIB
+
+
+def test_stream_file_range_resume(s3_stream_object):
+    """Streaming from an offset returns exactly the object's tail from there."""
+    key, data = s3_stream_object
+    off = len(data) // 3
+    assert b"".join(s3.stream_file(key, start_offset=off)) == data[off:]
+
+
+def test_stream_file_not_found_raises(s3_require_config):
+    """stream_file raises S3NotFoundError for a missing key."""
+    with pytest.raises(S3NotFoundError):
+        list(s3.stream_file(TEST_PREFIX + "does_not_exist_stream_xyz.bin"))
+
+
+def test_stream_file_offset_past_eof_yields_empty(s3_stream_object):
+    """start_offset at the object size yields nothing and does not raise."""
+    key, data = s3_stream_object
+    assert list(s3.stream_file(key, start_offset=len(data))) == []

--- a/tools/src/rakam_systems_tools/utils/__init__.py
+++ b/tools/src/rakam_systems_tools/utils/__init__.py
@@ -3,12 +3,14 @@ AI utilities for the Rakam System Core.
 """
 
 from . import s3
+from . import ndjson
 from . import logging
 from . import metrics
 from . import tracing
 
 __all__ = [
     "s3",
+    "ndjson",
     "logging",
     "metrics",
     "tracing",

--- a/tools/src/rakam_systems_tools/utils/ndjson.py
+++ b/tools/src/rakam_systems_tools/utils/ndjson.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+"""
+Byte-level NDJSON streaming for rakam_systems.
+
+``iter_ndjson_lines`` turns a byte-chunk stream (e.g. from ``s3.stream_file``)
+into NDJSON records, yielding ``(line_bytes, end_offset)`` where ``end_offset``
+is the absolute byte offset past the record's terminating newline — the resume
+checkpoint consumed by downstream ingestion stages.
+
+The split is on the ``\n`` byte ONLY. ``str.splitlines()`` also breaks on
+U+2028, U+2085 and ``\r``, which shatters records whose JSON string values
+(email bodies) legitimately contain those characters. Doing the split at the
+byte level is the canonical fix for that corruption.
+"""
+
+import json
+from typing import Iterable, Iterator, Optional
+
+
+def iter_ndjson_lines(
+    chunks: Iterable[bytes],
+    start_offset: int = 0,
+    skip_partial_first_line: bool = False,
+) -> Iterator[tuple[bytes, int]]:
+    r"""Split a byte-chunk stream into NDJSON records on the ``\n`` byte only.
+
+    Yields ``(line_bytes, end_offset)`` where ``end_offset`` is the absolute
+    byte offset past the record's terminating newline — the resume checkpoint.
+
+    - Splits on ``b"\n"`` ONLY (never ``str.splitlines()``); U+2028 / U+2085 /
+      ``\r`` inside a JSON string value stay intact.
+    - Carries a partial-line buffer across chunk boundaries.
+    - Blank lines are skipped (not yielded).
+    - Trailing bytes without a final newline are yielded as a record.
+    - ``skip_partial_first_line=True`` drops the first (assumed partial) line —
+      used with a mid-object Range resume so we start on a clean record boundary.
+
+    Args:
+        chunks: Any iterable of byte chunks (e.g. ``s3.stream_file(...)``).
+        start_offset: Absolute byte offset the first chunk begins at, so the
+            yielded ``end_offset`` values are absolute for a ranged resume.
+        skip_partial_first_line: Drop everything up to and including the first
+            newline, landing on a clean record boundary after a mid-object read.
+
+    Yields:
+        tuple[bytes, int]: ``(line_bytes, end_offset)`` per record.
+    """
+    buffer = b""
+    offset = start_offset
+    dropping = skip_partial_first_line
+
+    for chunk in chunks:
+        buffer += chunk
+        # Split off every complete line; the remainder (no trailing \n yet)
+        # stays in the buffer for the next chunk.
+        while True:
+            newline = buffer.find(b"\n")
+            if newline == -1:
+                break
+            line = buffer[:newline]
+            buffer = buffer[newline + 1:]
+            offset += newline + 1
+            if dropping:
+                # First newline consumed — the partial head is behind us.
+                dropping = False
+                continue
+            if line:
+                yield line, offset
+
+    # Trailing bytes with no final newline are a final record — unless we were
+    # still waiting to drop the partial first line (the whole tail was it).
+    if buffer and not dropping:
+        offset += len(buffer)
+        yield buffer, offset
+
+
+def stream_ndjson_from_s3(
+    key: str,
+    bucket: Optional[str] = None,
+    start_offset: int = 0,
+) -> Iterator[tuple[dict, int]]:
+    """Stream an S3 NDJSON object as ``(record_dict, end_offset)`` records.
+
+    Wires T1.1's ``s3.stream_file`` into ``iter_ndjson_lines`` and JSON-decodes
+    each record. When ``start_offset > 0``, issues the ranged read and drops the
+    first partial line so decoding starts on a clean record boundary.
+
+    Lives here (not in ``iter_ndjson_lines``) so JSON decoding stays out of the
+    pure splitter and so ``rakam_systems_vectorstore`` never pulls in an S3
+    dependency; the S3 import is lazy.
+
+    Args:
+        key: The S3 object key.
+        bucket: Bucket name (defaults to ``S3_BUCKET_NAME``).
+        start_offset: Absolute byte offset to resume from; 0 reads from the top.
+
+    Yields:
+        tuple[dict, int]: ``(record_dict, end_offset)`` per NDJSON record.
+    """
+    from rakam_systems_tools.utils.s3 import s3
+
+    chunks = s3.stream_file(key, bucket=bucket, start_offset=start_offset)
+    for line, end_offset in iter_ndjson_lines(
+        chunks,
+        start_offset=start_offset,
+        skip_partial_first_line=start_offset > 0,
+    ):
+        yield json.loads(line.decode("utf-8")), end_offset
+
+
+__all__ = [
+    "iter_ndjson_lines",
+    "stream_ndjson_from_s3",
+]

--- a/tools/src/rakam_systems_tools/utils/ndjson.py
+++ b/tools/src/rakam_systems_tools/utils/ndjson.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """
 Byte-level NDJSON streaming for rakam_systems.
 
@@ -13,6 +11,7 @@ U+2028, U+2085 and ``\r``, which shatters records whose JSON string values
 (email bodies) legitimately contain those characters. Doing the split at the
 byte level is the canonical fix for that corruption.
 """
+from __future__ import annotations
 
 import json
 from typing import Iterable, Iterator, Optional

--- a/tools/src/rakam_systems_tools/utils/s3/s3.py
+++ b/tools/src/rakam_systems_tools/utils/s3/s3.py
@@ -25,7 +25,7 @@ Configuration is read from environment variables:
 """
 
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterator, List, Optional
 
 try:
     import boto3
@@ -46,6 +46,8 @@ _S3_BUCKET_NAME = os.getenv("S3_BUCKET_NAME")
 
 # Singleton client instance
 _client: Optional[Any] = None
+
+_DEFAULT_CHUNK_SIZE = 1024 * 1024  # 1 MiB — matches the prototyped brick reads
 
 
 class S3Error(Exception):
@@ -217,6 +219,66 @@ def download_file(
         if error_code == 'NoSuchKey' or error_code == '404':
             raise S3NotFoundError(f"File not found: '{key}'")
         raise S3Error(f"Failed to download file '{key}': {error_code} - {e}")
+
+
+def stream_file(
+    key: str,
+    bucket: Optional[str] = None,
+    chunk_size: int = _DEFAULT_CHUNK_SIZE,
+    start_offset: int = 0,
+) -> Iterator[bytes]:
+    """
+    Yield an object's Body in bounded ``chunk_size`` chunks.
+
+    Peak memory is ~one chunk regardless of object size. When ``start_offset > 0``,
+    issues a ranged request (``Range: bytes=<start_offset>-``) so only the tail is
+    fetched — the resume primitive for byte-offset checkpointing.
+
+    Args:
+        key: The S3 object key (path/filename).
+        bucket: Bucket name (defaults to S3_BUCKET_NAME).
+        chunk_size: Maximum size in bytes of each yielded chunk.
+        start_offset: Byte offset to resume from; 0 reads the whole object.
+
+    Yields:
+        bytes: Successive chunks of the object body, each up to ``chunk_size``.
+
+    Raises:
+        S3NotFoundError: If the object does not exist.
+        S3Error: If the read fails.
+
+    Note:
+        Closes the Body when the generator is exhausted or garbage-collected.
+        A ``start_offset`` past the end of the object yields nothing and returns
+        cleanly — an empty tail is a valid resume state.
+    """
+    client = get_client()
+    bucket = bucket or _S3_BUCKET_NAME
+
+    get_args = {"Bucket": bucket, "Key": key}
+    if start_offset > 0:
+        get_args["Range"] = f"bytes={start_offset}-"
+
+    try:
+        response = client.get_object(**get_args)
+    except ClientError as e:
+        error_code = e.response.get("Error", {}).get("Code", "Unknown")
+        if error_code == "NoSuchKey" or error_code == "404":
+            raise S3NotFoundError(f"File not found: '{key}'")
+        # A start_offset at/past EOF is a valid resume state, not an error.
+        if error_code == "InvalidRange":
+            return
+        raise S3Error(f"Failed to stream file '{key}': {error_code} - {e}")
+
+    body = response["Body"]
+    try:
+        while True:
+            chunk = body.read(chunk_size)
+            if not chunk:
+                break
+            yield chunk
+    finally:
+        body.close()
 
 
 def delete_file(key: str, bucket: Optional[str] = None) -> bool:
@@ -468,6 +530,7 @@ __all__ = [
     # File operations
     "upload_file",
     "download_file",
+    "stream_file",
     "delete_file",
     "file_exists",
     "list_files",


### PR DESCRIPTION
## Summary
Capability-layer streaming primitives for the data-ingestion redesign (Notion §3.0). Fixes the "streaming isn't in rakam-systems-tools" workaround **at the source** — this is the primitive the whole engine's bounded-memory guarantee rests on. Additive to `rakam-systems-tools`; version bumped **0.2.2 → 0.3.0**.

- **T1.1** (this push) — `s3.stream_file(key, bucket=None, chunk_size=1MiB, start_offset=0) -> Iterator[bytes]`: chunked `get_object` Body + `Range: bytes=<off>-` resume; `S3NotFoundError` on 404; offset-past-EOF yields cleanly; Body closed in `finally`. The `(record, end_offset)` resume tuple is the engine's watermark contract.
- **T1.2** (Wave 2, appends to this branch) — NDJSON streaming helper (newline-byte split + cross-chunk partial-line buffer); the canonical home for the splitlines-corruption fix currently trapped in brick PRs #14/#56.

## Test plan
- `cd tools && uv run pytest src/rakam_systems_tools/tests/test_s3.py -v` — 5 new streaming tests collect + self-skip without S3 creds (live-S3 integration, run in CI); generator logic verified vs a fake botocore client.

## Impact
- **Additive, zero existing-symbol changes**; `download_file` untouched.
- Supersedes the in-brick streaming in draft PRs #14 / #56 (to be closed).
- **Release held** — do not tag until the redesign GO gate.
- ⚠️ Draft: T1.2 lands next; do not review as complete yet.

Tickets: `specs/data-ingestion-redesign/tickets/T1.1,T1.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)