### PR TITLE
fix(tools): don't drop the boundary record on checkpoint resume (stream_ndjson_from_s3)

### DIFF
--- a/tools/src/rakam_systems_tools/tests/test_ndjson.py
+++ b/tools/src/rakam_systems_tools/tests/test_ndjson.py
@@ -157,18 +157,56 @@ def s3_ndjson_object():
     s3.delete_file(key)
 
 
-def test_stream_ndjson_from_s3_roundtrip_and_resume(s3_ndjson_object):
-    """Full stream matches source; a mid-record resume lands on a clean record."""
+def test_stream_ndjson_from_s3_default_resume_keeps_boundary_record(monkeypatch):
+    """Regression: resuming from a checkpoint ``end_offset`` (a clean boundary)
+    must NOT drop the record that starts at that boundary. No S3 — the reader is
+    faked, so this guards the wrapper's skip decision on every run.
+    """
+    from rakam_systems_tools.utils.s3 import s3 as s3mod
+
+    data = b'{"a":1}\n{"b":2}\n{"c":3}\n'
+
+    def fake_stream_file(key, bucket=None, chunk_size=1024, start_offset=0):
+        yield data[start_offset:]
+
+    monkeypatch.setattr(s3mod, "stream_file", fake_stream_file)
+
+    full = list(stream_ndjson_from_s3("k"))
+    assert [r for r, _ in full] == [{"a": 1}, {"b": 2}, {"c": 3}]
+
+    # end_offset yielded after the first record is a clean boundary.
+    checkpoint = full[0][1]
+    resumed = list(stream_ndjson_from_s3("k", start_offset=checkpoint))
+    assert [r for r, _ in resumed] == [{"b": 2}, {"c": 3}]  # {"b":2} NOT dropped
+    assert resumed[-1][1] == len(data)
+
+
+def test_stream_ndjson_from_s3_roundtrip_and_checkpoint_resume(s3_ndjson_object):
+    """Full stream matches source; resuming from a checkpoint end_offset yields
+    the next record onward without dropping the boundary record."""
     key, records, size = s3_ndjson_object
 
     streamed = list(stream_ndjson_from_s3(key))
     assert [r for r, _ in streamed] == records
     assert streamed[-1][1] == size
 
-    # Resume from a byte offset that lands inside some record.
+    # Resume from a real checkpoint: the end_offset yielded after record k.
+    k = len(records) // 2
+    checkpoint = streamed[k][1]
+    resumed = list(stream_ndjson_from_s3(key, start_offset=checkpoint))
+    assert [r for r, _ in resumed] == records[k + 1:]  # record k+1 not dropped
+    assert resumed[-1][1] == size
+
+
+def test_stream_ndjson_from_s3_arbitrary_offset_skips_partial(s3_ndjson_object):
+    """With skip_partial_first_line=True, an arbitrary mid-record offset skips
+    the shattered partial and starts on the next whole record."""
+    key, records, size = s3_ndjson_object
+
     mid = size // 2
-    resumed = list(stream_ndjson_from_s3(key, start_offset=mid))
-    # It must skip the shattered partial and start on the next whole record.
+    resumed = list(
+        stream_ndjson_from_s3(key, start_offset=mid, skip_partial_first_line=True)
+    )
     assert resumed[0][0] in records
     resume_index = records.index(resumed[0][0])
     assert [r for r, _ in resumed] == records[resume_index:]

--- a/tools/src/rakam_systems_tools/utils/ndjson.py
+++ b/tools/src/rakam_systems_tools/utils/ndjson.py
@@ -78,12 +78,20 @@ def stream_ndjson_from_s3(
     key: str,
     bucket: Optional[str] = None,
     start_offset: int = 0,
+    skip_partial_first_line: bool = False,
 ) -> Iterator[tuple[dict, int]]:
     """Stream an S3 NDJSON object as ``(record_dict, end_offset)`` records.
 
     Wires T1.1's ``s3.stream_file`` into ``iter_ndjson_lines`` and JSON-decodes
-    each record. When ``start_offset > 0``, issues the ranged read and drops the
-    first partial line so decoding starts on a clean record boundary.
+    each record.
+
+    ``start_offset`` is meant to be a checkpoint previously yielded as
+    ``end_offset`` — always the byte just past a record's terminating newline,
+    i.e. a clean record boundary. So the byte at ``start_offset`` is the start of
+    the next unprocessed record and is NOT dropped. Only set
+    ``skip_partial_first_line=True`` when resuming from an arbitrary byte offset
+    that may land mid-record (not a checkpoint) — otherwise the record sitting on
+    the boundary would be silently lost.
 
     Lives here (not in ``iter_ndjson_lines``) so JSON decoding stays out of the
     pure splitter and so ``rakam_systems_vectorstore`` never pulls in an S3
@@ -93,6 +101,9 @@ def stream_ndjson_from_s3(
         key: The S3 object key.
         bucket: Bucket name (defaults to ``S3_BUCKET_NAME``).
         start_offset: Absolute byte offset to resume from; 0 reads from the top.
+            A checkpoint ``end_offset`` is a clean boundary — no record is dropped.
+        skip_partial_first_line: Drop the first (partial) line. Only for resuming
+            from an arbitrary, non-checkpoint offset that may split a record.
 
     Yields:
         tuple[dict, int]: ``(record_dict, end_offset)`` per NDJSON record.
@@ -103,7 +114,7 @@ def stream_ndjson_from_s3(
     for line, end_offset in iter_ndjson_lines(
         chunks,
         start_offset=start_offset,
-        skip_partial_first_line=start_offset > 0,
+        skip_partial_first_line=skip_partial_first_line,
     ):
         yield json.loads(line.decode("utf-8")), end_offset
 


### PR DESCRIPTION
## Summary
Follow-up bugfix from the code review of #130 (T1.2 NDJSON helper, now merged to main).

`stream_ndjson_from_s3` set `skip_partial_first_line = start_offset > 0`, treating *any* non-zero offset as mid-record. But the primitive documents `end_offset` (the byte just past a record's `\n`) as **the resume checkpoint** — always a clean boundary. So resuming from a real checkpoint dropped the record sitting on that boundary: after processing record R, checkpoint `E` → `stream_ndjson_from_s3(key, start_offset=E)` silently lost record R+1.

Currently latent (the engine resumes by watermark-*field*, not byte offset), but it's a shipped primitive whose own docstring advertises exactly the usage that breaks, and the existing test only covered the arbitrary-mid-record case that happened to be the one where skipping is correct.

## Fix
- Make `skip_partial_first_line` an **explicit param, default `False`** on `stream_ndjson_from_s3`. A checkpoint `end_offset` is a clean boundary → the boundary record is kept. Set `True` only when resuming from an arbitrary, non-checkpoint offset that may split a record (capability preserved). `iter_ndjson_lines` is unchanged — it already honors the flag faithfully.
- Docstring corrected to state the contract.

## Test plan
`cd tools && uv run --python 3.12 pytest src/rakam_systems_tools/tests/test_ndjson.py -v` → **7 pass / 2 skip**.
- New **infra-free regression** `test_stream_ndjson_from_s3_default_resume_keeps_boundary_record` (faked reader) proves the boundary record is not dropped — runs on every CI run.
- `test_stream_ndjson_from_s3_roundtrip_and_checkpoint_resume` (S3 integration) now resumes from a real `end_offset` and asserts no drop.
- `test_stream_ndjson_from_s3_arbitrary_offset_skips_partial` keeps coverage of the explicit-skip path.

## Impact
- Additive param (default preserves no behavior change for `start_offset=0`); **no version bump, no release** (main stays 0.2.2, consistent with the held release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)