### PR TITLE
fix(documents): report the installed version instead of a hand-written literal

### DIFF
--- a/documents/src/rakam_systems_documents/__init__.py
+++ b/documents/src/rakam_systems_documents/__init__.py
@@ -7,6 +7,9 @@ belong to the caller.
 """
 from __future__ import annotations
 
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _metadata_version
+
 from .prepare import prepare
 from .providers import DoclingOCRProvider, MistralOCRProvider, OCRProvider
 from .schema import (
@@ -19,7 +22,15 @@ from .schema import (
     split_pages,
 )
 
-__version__ = "0.2.0"
+# Read from the installed distribution rather than restated here. The release
+# workflow bumps `pyproject.toml` only, so a hand-written literal drifts on the
+# very next release: this one said "0.2.0" while the published package was
+# 0.1.1 — a version that never existed on PyPI. pyproject is the single source
+# of truth.
+try:
+    __version__ = _metadata_version("rakam-systems-documents")
+except PackageNotFoundError:  # running from a source tree, not installed
+    __version__ = "0.0.0+unknown"
 
 __all__ = [
     "prepare",
@@ -29,8 +40,8 @@ __all__ = [
     "OCRProvider",
     "MistralOCRProvider",
     "DoclingOCRProvider",
-    # Page segmentation (0.2.0) — consumers slice on the shared constant
-    # rather than re-deriving the marker.
+    # Page segmentation — consumers slice on the shared constant rather than
+    # re-deriving the marker.
     "PAGE_DELIMITER",
     "PAGE_DELIMITER_RE",
     "page_delimiter",


### PR DESCRIPTION
## Summary

The published **0.1.1 reports `__version__ == "0.2.0"`** — a version that never
existed on PyPI. The 0.2.0 branch hand-bumped the literal; the release then
reverted `pyproject.toml` to 0.1.0 (`bdd9ece`) and patch-bumped it to 0.1.1
(`ff83a17`), and nothing touched the literal.

Setting it to `"0.1.1"` would be correct only until the next release — the
release workflow's bump step rewrites `pyproject.toml` alone, so any restated
literal drifts again immediately. This reads it from the **installed
distribution** instead, so `pyproject.toml` is the single source of truth and
the drift cannot recur.

`__version__` is kept rather than deleted: it has been exported since 0.1.0, so
removing it would be an API removal — even though no sibling package in this repo
declares one.

## Test plan

- Built and installed into a clean venv: `m.__version__` ==
  `importlib.metadata.version("rakam-systems-documents")` == **0.1.1**.
- 24 package tests pass.
- Falls back to `0.0.0+unknown` when imported from a source tree rather than an
  install, so a dev checkout does not raise.

## Impact

- Behaviour change is limited to the value of `__version__`. Nothing in our repos
  reads it today (grepped), so nothing breaks; it stops lying to anyone who does.
- Adds no dependency — `importlib.metadata` is stdlib on the supported Pythons
  (>=3.10).
- **Needs a release to have any effect**: the fix only matters in a published
  artifact, so this wants a `documents` patch (→ 0.1.2) after merge. Until then
  the live 0.1.1 keeps misreporting.
